### PR TITLE
feat: implement Landelijke Aanpak Adreskwaliteit (LAA) with proper la…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,313 @@
+# Regels voor het omzetten van wetten naar YAML
+
+Dit document beschrijft de werkwijze voor het correct implementeren van Nederlandse wetgeving in YAML formaat volgens het regelrecht-laws schema.
+
+## Algemene principes
+
+### 1. Volg de praktijk, niet alleen de theorie
+- **Wat de wet toestaat ≠ wat er daadwerkelijk gebruikt wordt**
+- Onderzoek altijd wat er in de praktijk gebeurt
+- Implementeer realistische databronnen die daadwerkelijk beschikbaar zijn
+- Voorbeeld: LAA wet staat nutsverbruiksgegevens toe (Art. 28e), maar deze worden niet gebruikt in praktijk
+
+### 2. Juiste wet bij juiste organisatie
+- Elke wet/regeling hoort bij de organisatie die deze uitvoert
+- Splits wetten op als meerdere organisaties betrokken zijn
+- Gebruik `service` field voor de uitvoerende organisatie
+
+**Voorbeelden:**
+```yaml
+# Wet BAG
+service: "KADASTER"  # Kadaster distribueert BAG data
+
+# BRP Terugmeldplicht
+service: "BELASTINGDIENST"  # Belastingdienst meldt twijfel
+service: "TOESLAGEN"        # Toeslagen meldt twijfel
+service: "CJIB"             # CJIB meldt twijfel
+
+# LAA
+service: "RvIG"  # RvIG coördineert LAA namens minister BZK
+```
+
+### 3. Gebruik service_references waar mogelijk
+- Vermijd directe `source_reference` als gegevens van andere diensten komen
+- Gebruik `input` met `service_reference` voor gegevens van andere wetten
+- Dit creëert een netwerk van onderling verbonden wetten
+
+**Voorbeeld:**
+```yaml
+input:
+  - name: "BAG_GEBRUIKSDOEL"
+    type: "string"
+    service_reference:
+      service: "KADASTER"
+      law: "wet_bag"
+      field: "gebruiksdoel"
+      parameters:
+        - name: "ADRES"
+          reference: "$ADRES"
+```
+
+### 4. Parameters: required vs optional
+- Maak parameters alleen `required: true` als ze **altijd** nodig zijn
+- Analyseer verschillende gebruiksscenario's
+- Voorbeeld LAA:
+  - `ADRES` → required (altijd nodig)
+  - `BSN` → optional (alleen bij persoonsgerichte meldingen)
+
+## Onderzoeksproces
+
+### Stap 1: Identificeer de wet
+1. Zoek de officiële wettekst op wetten.overheid.nl
+2. Bepaal het BWB-ID (bijv. BWBR0033715)
+3. Identificeer relevante artikelen
+
+### Stap 2: Bepaal wat de wet daadwerkelijk regelt
+**Let op**: Niet alle wetten regelen databronnen!
+
+**Voorbeelden:**
+- **LAA wet** regelt NIET de adresgegevens zelf, maar de **methode** om adreskwaliteit te controleren
+- **Wet BRP Art. 2.34** regelt de **terugmeldplicht**, niet de gegevens
+- **Wet BAG** regelt WEL de gegevens (gebruiksdoel, oppervlakte, etc.)
+
+### Stap 3: Onderzoek de praktijk
+Zoek naar:
+- Implementatierapporten
+- Evaluaties
+- Algoritmeregister (algoritmes.overheid.nl)
+- Beleidsregels en circulaires
+- Welke organisaties zijn daadwerkelijk signaalleveranciers?
+
+**Voorbeeld LAA:**
+```
+Wet zegt: nutsverbruik, waterverbruik, BAG, BRP mogelijk
+Praktijk: alleen Belastingdienst, Toeslagen, CJIB meldingen + BAG + BRP
+→ Implementeer wat daadwerkelijk wordt gebruikt
+```
+
+### Stap 4: Identificeer databronnen
+Bepaal voor elke databron:
+1. **Wie is eigenaar?** (welke organisatie heeft de data)
+2. **Bestaat er al een YAML?** (check bestaande wetten)
+3. **Moet nieuwe YAML gemaakt worden?**
+
+## Structuur en naamgeving
+
+### Directory structuur
+```
+laws/
+  wet_naam/
+    ORGANISATIE-YYYY-MM-DD.yaml          # Hoofdwet
+    subdomein/
+      ORGANISATIE-YYYY-MM-DD.yaml        # Specifieke implementatie
+```
+
+**Voorbeelden:**
+```
+laws/wet_brp/
+  RvIG-2020-01-01.yaml                   # BRP algemeen
+  terugmelding/
+    BELASTINGDIENST-2023-05-15.yaml      # Terugmeldplicht per organisatie
+    TOESLAGEN-2023-05-15.yaml
+    CJIB-2023-05-15.yaml
+  laa/
+    RvIG-2023-05-15.yaml                 # LAA coördinatie
+
+laws/wet_bag/
+  KADASTER-2018-07-28.yaml               # BAG distributie
+```
+
+### Bestandsnaamconventies
+- Format: `{SERVICE}-{YYYY-MM-DD}.yaml`
+- Service: HOOFDLETTERS
+- Datum: `valid_from` datum uit de wet
+- Gebruik organisatie-afkortingen: BELASTINGDIENST, TOESLAGEN, CJIB, KADASTER, RvIG
+
+## YAML velden specificatie
+
+### Verplichte metadata
+```yaml
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx  # Let op: versie 4 UUID (4 op positie 13)
+name: "Korte beschrijvende naam"
+law: wet_naam
+law_type: "FORMELE_WET"
+legal_character: "BESCHIKKING"  # of "BESLUIT_VAN_ALGEMENE_STREKKING"
+decision_type: "TOEKENNING"     # of "ANDERE_HANDELING", etc.
+valid_from: 2023-05-15
+service: "ORGANISATIE"
+```
+
+### Legal basis structuur
+Elk veld/actie moet een `legal_basis` hebben:
+```yaml
+legal_basis:
+  law: "Volledige naam van de wet"
+  bwb_id: "BWBR0012345"
+  article: "2.34"
+  paragraph: "1"           # optioneel
+  sentence: "2"            # optioneel
+  url: "https://wetten.overheid.nl/BWBR0012345/2024-01-01#..."
+  juriconnect: "jci1.3:c:BWBR0012345&artikel=2.34&lid=1&z=2024-01-01&g=2024-01-01"
+  explanation: "Artikel 2.34 lid 1 bepaalt dat..."
+```
+
+### Parameters vs Sources vs Input
+
+**Parameters** - door gebruiker aangeleverd:
+```yaml
+parameters:
+  - name: "BSN"
+    type: "string"
+    required: true  # of false
+    description: "BSN van de persoon"
+```
+
+**Sources** - uit eigen databron van deze organisatie:
+```yaml
+sources:
+  - name: "GEBOORTEDATUM"
+    type: "date"
+    source_reference:
+      table: "personen"
+      field: "geboortedatum"
+      select_on:
+        - name: "bsn"
+          value: "$BSN"
+```
+
+**Input** - van andere organisaties/wetten:
+```yaml
+input:
+  - name: "BAG_GEBRUIKSDOEL"
+    type: "string"
+    service_reference:
+      service: "KADASTER"
+      law: "wet_bag"
+      field: "gebruiksdoel"
+      parameters:
+        - name: "ADRES"
+          reference: "$ADRES"
+```
+
+### Output specificatie
+```yaml
+output:
+  - name: "heeft_recht"
+    description: "Of persoon recht heeft op toeslag"
+    type: "boolean"
+    temporal:
+      type: "point_in_time"
+      reference: "$calculation_date"
+    legal_basis:
+      law: "..."
+      # etc.
+```
+
+## Validatie checklist
+
+Voordat je commit:
+1. ✅ Run `python3 script/validate.py`
+2. ✅ Controleer: "All service references have corresponding outputs"
+3. ✅ Controleer: "All variables are properly defined"
+4. ✅ UUID is versie 4 format (4 op positie 13)
+5. ✅ Alle legal_basis velden zijn ingevuld
+6. ✅ Service naam komt overeen met daadwerkelijke organisatie
+
+## Veelgemaakte fouten
+
+### ❌ Fout: Theoretische databronnen gebruiken
+```yaml
+# FOUT: Staat in wet maar wordt niet gebruikt
+sources:
+  - name: "NUTSVERBRUIK"
+    source_reference:
+      table: "nutsverbruik"  # Bestaat niet bij RvIG!
+```
+
+### ✅ Correct: Realistische databronnen
+```yaml
+# CORRECT: Wordt daadwerkelijk gebruikt
+input:
+  - name: "BELASTINGDIENST_TWIJFEL"
+    service_reference:
+      service: "BELASTINGDIENST"
+      law: "wet_brp"
+      field: "heeft_gerede_twijfel_adres"
+```
+
+### ❌ Fout: Alles in één YAML
+```yaml
+# FOUT: LAA met alle meldingen in één bestand
+name: "LAA met alle meldingen"
+service: "RvIG"
+# ... bevat ook Belastingdienst logica
+```
+
+### ✅ Correct: Gesplitste YAMLs
+```yaml
+# CORRECT: Elke organisatie eigen YAML
+# wet_brp/terugmelding/BELASTINGDIENST-2023-05-15.yaml
+service: "BELASTINGDIENST"
+
+# wet_brp/laa/RvIG-2023-05-15.yaml
+service: "RvIG"
+# gebruikt service_references naar Belastingdienst
+```
+
+### ❌ Fout: Verkeerde service naam
+```yaml
+# FOUT: RvIG is distributor, niet eigenaar
+name: "BAG gegevens"
+service: "RvIG"  # FOUT!
+```
+
+### ✅ Correct: Juiste eigenaar
+```yaml
+# CORRECT: Kadaster distribueert BAG
+name: "BAG gegevens"
+service: "KADASTER"
+```
+
+## Bronnen voor onderzoek
+
+### Primaire bronnen
+- **wetten.overheid.nl** - Officiële wetteksten
+- **zoek.officielebekendmakingen.nl** - Staatsbladen, kamerstukken
+- **algoritmes.overheid.nl** - Algoritmeregister met profielen
+
+### Secundaire bronnen
+- **rijksoverheid.nl** - Beleid en uitvoering
+- **Organisatie websites** - RvIG, Kadaster, Belastingdienst, etc.
+- **VNG publicaties** - Gemeentelijke uitvoering
+- **Evaluatierapporten** - Praktijkervaringen
+
+## Voorbeeld: Volledige workflow LAA
+
+1. **Onderzoek wet**: Besluit BRP Art. 28a-28g (LAA)
+2. **Identificeer wat wet regelt**: Methode voor adreskwaliteitscontrole, NIET de gegevens zelf
+3. **Onderzoek praktijk**:
+   - Signaalleveranciers: Belastingdienst, Toeslagen, CJIB
+   - Databronnen: BRP (aantal bewoners), BAG (gebruiksdoel)
+   - Géén nutsverbruik in praktijk
+4. **Maak YAMLs**:
+   - `wet_bag/KADASTER-2018-07-28.yaml` (BAG gegevens)
+   - `wet_brp/terugmelding/BELASTINGDIENST-2023-05-15.yaml` (Terugmeldplicht)
+   - `wet_brp/terugmelding/TOESLAGEN-2023-05-15.yaml` (Terugmeldplicht)
+   - `wet_brp/terugmelding/CJIB-2023-05-15.yaml` (Terugmeldplicht)
+   - `wet_brp/laa/RvIG-2023-05-15.yaml` (LAA coördinatie met service_references)
+5. **Valideer**: `python3 script/validate.py`
+6. **Commit**: Met duidelijke beschrijving
+
+## Tips
+
+- **Begin simpel**: Implementeer eerst de hoofdstroom, voeg later edge cases toe
+- **Hergebruik**: Kijk altijd eerst naar bestaande YAMLs voor voorbeelden
+- **Documenteer**: Leg in comments uit waarom keuzes gemaakt zijn
+- **Test service references**: Controleer dat alle referenced outputs bestaan
+- **Wees kritisch**: Als iets theoretisch mogelijk is maar niet gebruikt wordt, laat het weg
+
+---
+
+*Laatst bijgewerkt: 2025-10-01*
+*Schema versie: v0.1.6*

--- a/laws/wet_bag/KADASTER-2018-07-28.yaml
+++ b/laws/wet_bag/KADASTER-2018-07-28.yaml
@@ -1,0 +1,204 @@
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: 9c4e8f2a-7d3b-4e1f-8a5c-6f9d2e3a7b4c
+name: Bepalen BAG gegevens
+law: wet_bag
+law_type: "FORMELE_WET"
+legal_character: "BESCHIKKING"
+decision_type: "TOEKENNING"
+valid_from: 2018-07-28
+service: "KADASTER"
+legal_basis:
+  law: "Wet basisregistratie adressen en gebouwen"
+  bwb_id: "BWBR0023466"
+  article: "1"
+  url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+  juriconnect: "jci1.3:c:BWBR0023466&artikel=1&z=2018-07-28&g=2018-07-28"
+  explanation: "Artikel 1 Wet BAG bepaalt dat de basisregistratie adressen en gebouwen bevat gegevens over adressen, gebouwen en standplaatsen"
+description: >
+  Regels voor het bepalen van gegevens uit de Basisregistratie Adressen en Gebouwen (BAG).
+  Het Kadaster verzorgt de landelijke voorziening waarin gemeenten hun BAG-gegevens aanleveren.
+  Overheidsorganen zijn verplicht deze authentieke gegevens te gebruiken bij hun publiekrechtelijke taken.
+
+references:
+  - law: "Wet BAG"
+    article: "1"
+    url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+  - law: "Wet BAG"
+    article: "2"
+    url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel2"
+  - law: "Wet BAG"
+    article: "6"
+    url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf2_Artikel6"
+
+properties:
+  parameters:
+    - name: "ADRES"
+      description: "Adresgegevens (postcode en huisnummer)"
+      type: "object"
+      required: true
+      legal_basis:
+        law: "Wet basisregistratie adressen en gebouwen"
+        bwb_id: "BWBR0023466"
+        article: "1"
+        url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+        juriconnect: "jci1.3:c:BWBR0023466&artikel=1&z=2018-07-28&g=2018-07-28"
+        explanation: "Artikel 1 bepaalt dat nummeraanduidingen (postcode + huisnummer) deel uitmaken van de BAG"
+
+  sources:
+    - name: "VERBLIJFSOBJECT"
+      description: "Verblijfsobject gegevens uit BAG"
+      type: "object"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      source_reference:
+        table: "bag_verblijfsobjecten"
+        fields: ["gebruiksdoel", "oppervlakte", "status", "bouwjaar"]
+        select_on:
+          - name: "postcode"
+            description: "Postcode van het adres"
+            type: "string"
+            value: "$ADRES.postcode"
+          - name: "huisnummer"
+            description: "Huisnummer van het adres"
+            type: "string"
+            value: "$ADRES.huisnummer"
+      legal_basis:
+        law: "Wet basisregistratie adressen en gebouwen"
+        bwb_id: "BWBR0023466"
+        article: "1"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+        juriconnect: "jci1.3:c:BWBR0023466&artikel=1&lid=1&z=2018-07-28&g=2018-07-28"
+        explanation: "Artikel 1 lid 1 onder c bepaalt dat verblijfsobjecten geregistreerd worden met hun kenmerken"
+
+  output:
+    - name: "gebruiksdoel"
+      description: "Gebruiksdoel van het verblijfsobject volgens Bouwbesluit 2012"
+      type: "string"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Wet basisregistratie adressen en gebouwen"
+        bwb_id: "BWBR0023466"
+        article: "1"
+        paragraph: "2"
+        url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+        juriconnect: "jci1.3:c:BWBR0023466&artikel=1&lid=2&z=2018-07-28&g=2018-07-28"
+        explanation: "Artikel 1 lid 2 bepaalt dat gebruiksdoel wordt geregistreerd"
+
+    - name: "oppervlakte"
+      description: "Gebruiksoppervlakte van het verblijfsobject in m²"
+      type: "number"
+      type_spec:
+        precision: 0
+        min: 1
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Wet basisregistratie adressen en gebouwen"
+        bwb_id: "BWBR0023466"
+        article: "1"
+        url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+        juriconnect: "jci1.3:c:BWBR0023466&artikel=1&z=2018-07-28&g=2018-07-28"
+        explanation: "Artikel 1 bepaalt dat oppervlakte als kenmerk wordt geregistreerd"
+
+    - name: "status"
+      description: "Status van het verblijfsobject"
+      type: "string"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Wet basisregistratie adressen en gebouwen"
+        bwb_id: "BWBR0023466"
+        article: "1"
+        url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+        juriconnect: "jci1.3:c:BWBR0023466&artikel=1&z=2018-07-28&g=2018-07-28"
+        explanation: "Artikel 1 bepaalt dat de status wordt geregistreerd"
+
+    - name: "is_woonfunctie"
+      description: "Of het verblijfsobject een woonfunctie heeft"
+      type: "boolean"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Wet basisregistratie adressen en gebouwen"
+        bwb_id: "BWBR0023466"
+        article: "2"
+        url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel2"
+        juriconnect: "jci1.3:c:BWBR0023466&artikel=2&z=2018-07-28&g=2018-07-28"
+        explanation: "Artikel 2 bepaalt verplicht gebruik van authentieke gegevens, waaronder gebruiksdoelen"
+
+  definitions:
+    WOON_GEBRUIKSDOELEN:
+      - "woonfunctie"
+    NIET_WOON_GEBRUIKSDOELEN:
+      - "bijeenkomstfunctie"
+      - "celfunctie"
+      - "gezondheidszorgfunctie"
+      - "industriefunctie"
+      - "kantoorfunctie"
+      - "logiesfunctie"
+      - "onderwijsfunctie"
+      - "sportfunctie"
+      - "winkelfunctie"
+      - "overige gebruiksfunctie"
+
+requirements:
+  - all:
+      - subject: "$ADRES"
+        operation: NOT_NULL
+        legal_basis:
+          law: "Wet basisregistratie adressen en gebouwen"
+          bwb_id: "BWBR0023466"
+          article: "1"
+          url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+          juriconnect: "jci1.3:c:BWBR0023466&artikel=1&z=2018-07-28&g=2018-07-28"
+          explanation: "Artikel 1 vereist adresgegevens voor opzoeken verblijfsobject"
+
+actions:
+  - output: "gebruiksdoel"
+    value: "$VERBLIJFSOBJECT.gebruiksdoel"
+    legal_basis:
+      law: "Wet basisregistratie adressen en gebouwen"
+      bwb_id: "BWBR0023466"
+      article: "1"
+      url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+      juriconnect: "jci1.3:c:BWBR0023466&artikel=1&z=2018-07-28&g=2018-07-28"
+      explanation: "Artikel 1 bepaalt registratie van gebruiksdoel"
+
+  - output: "oppervlakte"
+    value: "$VERBLIJFSOBJECT.oppervlakte"
+    legal_basis:
+      law: "Wet basisregistratie adressen en gebouwen"
+      bwb_id: "BWBR0023466"
+      article: "1"
+      url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+      juriconnect: "jci1.3:c:BWBR0023466&artikel=1&z=2018-07-28&g=2018-07-28"
+      explanation: "Artikel 1 bepaalt registratie van oppervlakte"
+
+  - output: "status"
+    value: "$VERBLIJFSOBJECT.status"
+    legal_basis:
+      law: "Wet basisregistratie adressen en gebouwen"
+      bwb_id: "BWBR0023466"
+      article: "1"
+      url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel1"
+      juriconnect: "jci1.3:c:BWBR0023466&artikel=1&z=2018-07-28&g=2018-07-28"
+      explanation: "Artikel 1 bepaalt registratie van status"
+
+  - output: "is_woonfunctie"
+    operation: IN
+    subject: "$VERBLIJFSOBJECT.gebruiksdoel"
+    values: "$WOON_GEBRUIKSDOELEN"
+    legal_basis:
+      law: "Wet basisregistratie adressen en gebouwen"
+      bwb_id: "BWBR0023466"
+      article: "2"
+      url: "https://wetten.overheid.nl/BWBR0023466/2018-07-28#Paragraaf1_Artikel2"
+      juriconnect: "jci1.3:c:BWBR0023466&artikel=2&z=2018-07-28&g=2018-07-28"
+      explanation: "Artikel 2 verplicht gebruik BAG-gegevens voor bepaling woonfunctie"

--- a/laws/wet_brp/laa/RvIG-2023-05-15.yaml
+++ b/laws/wet_brp/laa/RvIG-2023-05-15.yaml
@@ -1,0 +1,407 @@
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: 7f3e9a2b-5c4d-4e8f-9b1a-3d6c8f2e4a5b
+name: Landelijke Aanpak Adreskwaliteit (LAA)
+law: wet_brp
+law_type: "FORMELE_WET"
+legal_character: "BESCHIKKING"
+decision_type: "ANDERE_HANDELING"
+valid_from: 2023-05-15
+service: "RvIG"
+legal_basis:
+  law: "Besluit basisregistratie personen"
+  bwb_id: "BWBR0034306"
+  article: "28a"
+  url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28a"
+  juriconnect: "jci1.3:c:BWBR0034306&artikel=28a&z=2024-04-01&g=2024-04-01"
+  explanation: "Artikel 28a bepaalt de analysemethoden waarmee de minister gemeenten ondersteunt bij onderzoek naar juistheid van adresgegevens in de BRP"
+description: >
+  De Landelijke Aanpak Adreskwaliteit (LAA) regelt de ondersteuning door de minister van BZK aan
+  gemeenten bij het onderzoeken van de juistheid van adresgegevens in de Basisregistratie Personen.
+  De minister gebruikt analysemethoden (meldingen van Belastingdienst, Toeslagen en CJIB; profielen
+  op basis van BRP en BAG data) om signalen te genereren over mogelijk onjuiste adresregistraties.
+  Gemeenten zijn verplicht binnen 4 weken te reageren en binnen 6 maanden onderzoek af te ronden.
+
+references:
+  - law: "Besluit BRP"
+    article: "28a"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28a"
+  - law: "Besluit BRP"
+    article: "28b"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28b"
+  - law: "Besluit BRP"
+    article: "28c"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28c"
+  - law: "Besluit BRP"
+    article: "28d"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28d"
+  - law: "Besluit BRP"
+    article: "28e"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28e"
+  - law: "Besluit BRP"
+    article: "28f"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28f"
+  - law: "Besluit BRP"
+    article: "28g"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28g"
+
+properties:
+  parameters:
+    - name: "BSN"
+      description: "BSN van de persoon voor wie adres gecontroleerd wordt (optioneel, vereist bij persoonsgerichte meldingen)"
+      type: "string"
+      required: false
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28f"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28f"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28f&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28f bepaalt dat signalen BSN bevatten bij persoonsgerichte meldingen"
+
+    - name: "ADRES"
+      description: "Adresgegevens voor LAA analyse"
+      type: "object"
+      required: true
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28f"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28f"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28f&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28f bepaalt dat signalen gemeente- en adresgegevens bevatten"
+
+  sources:
+    - name: "AANTAL_BEWONERS"
+      description: "Aantal geregistreerde bewoners op adres uit BRP"
+      type: "number"
+      type_spec:
+        precision: 0
+        min: 0
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      source_reference:
+        table: "brp_adressen"
+        field: "aantal_bewoners"
+        select_on:
+          - name: "postcode"
+            description: "Postcode van het adres"
+            type: "string"
+            value: "$ADRES.postcode"
+          - name: "huisnummer"
+            description: "Huisnummer van het adres"
+            type: "string"
+            value: "$ADRES.huisnummer"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28e"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28e"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28e&lid=1&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28e lid 1 bepaalt dat woonsamenstellingsgegevens mogen worden verwerkt"
+
+  input:
+    # Meldingen van externe instanties (Art. 28a, 28b)
+    - name: "BELASTINGDIENST_TWIJFEL"
+      description: "Terugmelding Belastingdienst over adres"
+      type: "boolean"
+      service_reference:
+        service: "BELASTINGDIENST"
+        law: "wet_brp"
+        field: "heeft_gerede_twijfel_adres"
+        parameters:
+          - name: "BSN"
+            reference: "$BSN"
+          - name: "ADRES"
+            reference: "$ADRES"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28b"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28b"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28b&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28b bepaalt dat meldingen van bestuursorganen worden geanalyseerd"
+
+    - name: "TOESLAGEN_TWIJFEL"
+      description: "Terugmelding Dienst Toeslagen over adres"
+      type: "boolean"
+      service_reference:
+        service: "TOESLAGEN"
+        law: "wet_brp"
+        field: "heeft_gerede_twijfel_adres"
+        parameters:
+          - name: "BSN"
+            reference: "$BSN"
+          - name: "ADRES"
+            reference: "$ADRES"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28b"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28b"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28b&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28b bepaalt dat meldingen van bestuursorganen worden geanalyseerd"
+
+    - name: "CJIB_TWIJFEL"
+      description: "Terugmelding CJIB over adres (OBR profiel)"
+      type: "boolean"
+      service_reference:
+        service: "CJIB"
+        law: "wet_brp"
+        field: "heeft_gerede_twijfel_adres"
+        parameters:
+          - name: "BSN"
+            reference: "$BSN"
+          - name: "ADRES"
+            reference: "$ADRES"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28b"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28b"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28b&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28b bepaalt dat meldingen van bestuursorganen worden geanalyseerd"
+
+    # BAG data voor profielen (Art. 28c, 28e)
+    - name: "BAG_GEBRUIKSDOEL"
+      description: "Gebruiksdoel van verblijfsobject volgens BAG"
+      type: "string"
+      service_reference:
+        service: "KADASTER"
+        law: "wet_bag"
+        field: "gebruiksdoel"
+        parameters:
+          - name: "ADRES"
+            reference: "$ADRES"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28e"
+        paragraph: "2"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28e"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28e&lid=2&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28e lid 2 bepaalt dat gegevens over gebruik van panden mogen worden verwerkt"
+
+    - name: "BAG_IS_WOONFUNCTIE"
+      description: "Of verblijfsobject woonfunctie heeft volgens BAG"
+      type: "boolean"
+      service_reference:
+        service: "KADASTER"
+        law: "wet_bag"
+        field: "is_woonfunctie"
+        parameters:
+          - name: "ADRES"
+            reference: "$ADRES"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28e"
+        paragraph: "2"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28e"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28e&lid=2&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28e lid 2 bepaalt dat gegevens over gebruik van panden mogen worden verwerkt"
+
+  output:
+    - name: "genereer_signaal"
+      description: "Of er een signaal naar de gemeente moet worden gestuurd over mogelijk onjuiste adresregistratie"
+      type: "boolean"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28f"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28f"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28f&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28f bepaalt dat de minister signalen verstrekt aan colleges over adresgegevens waarbij gerede twijfel bestaat"
+
+    - name: "signaal_type"
+      description: "Type signaal: MELDING of PROFIEL"
+      type: "string"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28a"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28a"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28a&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28a bepaalt analysemethoden: meldingen en profielen (patroononderzoek leidt niet tot signalen)"
+
+    - name: "reactietermijn_weken"
+      description: "Termijn waarbinnen gemeente moet reageren (in weken)"
+      type: "number"
+      type_spec:
+        unit: "weeks"
+        precision: 0
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28g"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28g"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28g&lid=1&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28g lid 1 bepaalt dat het college binnen vier weken moet aangeven of het signaal tot aanpassing heeft geleid"
+
+    - name: "onderzoekstermijn_maanden"
+      description: "Maximale termijn voor afronding onderzoek (in maanden)"
+      type: "number"
+      type_spec:
+        unit: "months"
+        precision: 0
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28g"
+        paragraph: "2"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28g"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28g&lid=2&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28g lid 2 bepaalt dat onderzoek binnen zes maanden moet worden afgerond"
+
+  definitions:
+    HOOG_BEWONERS_DREMPEL: 5
+    REACTIETERMIJN_WEKEN: 4
+    ONDERZOEKSTERMIJN_MAANDEN: 6
+
+requirements:
+  - all:
+      - subject: "$ADRES"
+        operation: NOT_NULL
+        legal_basis:
+          law: "Besluit basisregistratie personen"
+          bwb_id: "BWBR0034306"
+          article: "28f"
+          url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28f"
+          juriconnect: "jci1.3:c:BWBR0034306&artikel=28f&z=2024-04-01&g=2024-04-01"
+          explanation: "Artikel 28f vereist minimaal adresgegevens voor signalering"
+
+actions:
+  - output: "genereer_signaal"
+    operation: OR
+    values:
+      # Methode 1: Analyse van meldingen (Art. 28a, 28b)
+      - subject: "$BELASTINGDIENST_TWIJFEL"
+        operation: EQUALS
+        value: true
+        legal_basis:
+          law: "Besluit basisregistratie personen"
+          bwb_id: "BWBR0034306"
+          article: "28b"
+          url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28b"
+          juriconnect: "jci1.3:c:BWBR0034306&artikel=28b&z=2024-04-01&g=2024-04-01"
+          explanation: "Melding Belastingdienst genereert signaal"
+      - subject: "$TOESLAGEN_TWIJFEL"
+        operation: EQUALS
+        value: true
+        legal_basis:
+          law: "Besluit basisregistratie personen"
+          bwb_id: "BWBR0034306"
+          article: "28b"
+          url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28b"
+          juriconnect: "jci1.3:c:BWBR0034306&artikel=28b&z=2024-04-01&g=2024-04-01"
+          explanation: "Melding Toeslagen genereert signaal"
+      - subject: "$CJIB_TWIJFEL"
+        operation: EQUALS
+        value: true
+        legal_basis:
+          law: "Besluit basisregistratie personen"
+          bwb_id: "BWBR0034306"
+          article: "28b"
+          url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28b"
+          juriconnect: "jci1.3:c:BWBR0034306&artikel=28b&z=2024-04-01&g=2024-04-01"
+          explanation: "Melding CJIB genereert signaal"
+
+      # Methode 2: Profielanalyse (Art. 28a, 28c)
+      - operation: AND
+        values:
+          - operation: GREATER_THAN
+            values:
+              - "$AANTAL_BEWONERS"
+              - "$HOOG_BEWONERS_DREMPEL"
+            legal_basis:
+              law: "Besluit basisregistratie personen"
+              bwb_id: "BWBR0034306"
+              article: "28c"
+              url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28c"
+              juriconnect: "jci1.3:c:BWBR0034306&artikel=28c&z=2024-04-01&g=2024-04-01"
+              explanation: "Hoog aantal bewoners is selectiefactor in profiel"
+          - subject: "$BAG_IS_WOONFUNCTIE"
+            operation: EQUALS
+            value: false
+            legal_basis:
+              law: "Besluit basisregistratie personen"
+              bwb_id: "BWBR0034306"
+              article: "28c"
+              url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28c"
+              juriconnect: "jci1.3:c:BWBR0034306&artikel=28c&z=2024-04-01&g=2024-04-01"
+              explanation: "Bewoners op niet-woonfunctie is selectiefactor in profiel"
+        legal_basis:
+          law: "Besluit basisregistratie personen"
+          bwb_id: "BWBR0034306"
+          article: "28a"
+          url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28a"
+          juriconnect: "jci1.3:c:BWBR0034306&artikel=28a&z=2024-04-01&g=2024-04-01"
+          explanation: "Artikel 28a bepaalt analyse met profielen als methode"
+    legal_basis:
+      law: "Besluit basisregistratie personen"
+      bwb_id: "BWBR0034306"
+      article: "28f"
+      url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28f"
+      juriconnect: "jci1.3:c:BWBR0034306&artikel=28f&z=2024-04-01&g=2024-04-01"
+      explanation: "Artikel 28f bepaalt verstrekking van signalen aan colleges"
+
+  - output: "signaal_type"
+    operation: IF
+    conditions:
+      - test:
+          operation: OR
+          values:
+            - subject: "$BELASTINGDIENST_TWIJFEL"
+              operation: EQUALS
+              value: true
+            - subject: "$TOESLAGEN_TWIJFEL"
+              operation: EQUALS
+              value: true
+            - subject: "$CJIB_TWIJFEL"
+              operation: EQUALS
+              value: true
+        then: "MELDING"
+      - else: "PROFIEL"
+    legal_basis:
+      law: "Besluit basisregistratie personen"
+      bwb_id: "BWBR0034306"
+      article: "28a"
+      url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28a"
+      juriconnect: "jci1.3:c:BWBR0034306&artikel=28a&z=2024-04-01&g=2024-04-01"
+      explanation: "Artikel 28a onderscheidt meldingen en profielen (patroononderzoek leidt niet tot signaal)"
+
+  - output: "reactietermijn_weken"
+    value: "$REACTIETERMIJN_WEKEN"
+    legal_basis:
+      law: "Besluit basisregistratie personen"
+      bwb_id: "BWBR0034306"
+      article: "28g"
+      paragraph: "1"
+      url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28g"
+      juriconnect: "jci1.3:c:BWBR0034306&artikel=28g&lid=1&z=2024-04-01&g=2024-04-01"
+      explanation: "Artikel 28g lid 1 bepaalt vier weken reactietermijn"
+
+  - output: "onderzoekstermijn_maanden"
+    value: "$ONDERZOEKSTERMIJN_MAANDEN"
+    legal_basis:
+      law: "Besluit basisregistratie personen"
+      bwb_id: "BWBR0034306"
+      article: "28g"
+      paragraph: "2"
+      url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.6_Artikel28g"
+      juriconnect: "jci1.3:c:BWBR0034306&artikel=28g&lid=2&z=2024-04-01&g=2024-04-01"
+      explanation: "Artikel 28g lid 2 bepaalt zes maanden onderzoekstermijn"

--- a/laws/wet_brp/terugmelding/BELASTINGDIENST-2023-05-15.yaml
+++ b/laws/wet_brp/terugmelding/BELASTINGDIENST-2023-05-15.yaml
@@ -1,0 +1,198 @@
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: 2a5c7e9f-4d8b-4e6a-9c1f-7e4d2a8b5c3e
+name: BRP Terugmeldplicht Belastingdienst
+law: wet_brp
+law_type: "FORMELE_WET"
+legal_character: "BESCHIKKING"
+decision_type: "ANDERE_HANDELING"
+valid_from: 2023-05-15
+service: "BELASTINGDIENST"
+legal_basis:
+  law: "Wet basisregistratie personen"
+  bwb_id: "BWBR0033715"
+  article: "2.34"
+  url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+  juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+  explanation: "Artikel 2.34 verplicht bestuursorganen gerede twijfel over BRP-gegevens te melden via de terugmeldvoorziening"
+description: >
+  De Belastingdienst heeft een wettelijke verplichting om twijfel over de juistheid van
+  adresgegevens in de BRP te melden. Dit gebeurt via de Terugmeldvoorziening (TMV) naar
+  gemeenten. De Belastingdienst ontdekt afwijkingen bij belastinginning, toeslagverstrekking
+  en adrescontroles.
+
+references:
+  - law: "Wet BRP"
+    article: "2.34"
+    url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+  - law: "Besluit BRP"
+    article: "28"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.5_Artikel28"
+
+properties:
+  parameters:
+    - name: "BSN"
+      description: "BSN van de persoon"
+      type: "string"
+      required: true
+      legal_basis:
+        law: "Wet basisregistratie personen"
+        bwb_id: "BWBR0033715"
+        article: "2.34"
+        url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+        juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+        explanation: "Artikel 2.34 vereist identificatie van persoon bij terugmelding"
+
+    - name: "ADRES"
+      description: "Adresgegevens die mogelijk onjuist zijn"
+      type: "object"
+      required: true
+      legal_basis:
+        law: "Wet basisregistratie personen"
+        bwb_id: "BWBR0033715"
+        article: "2.34"
+        url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+        juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+        explanation: "Artikel 2.34 vereist specificatie van het adresgegeven waarover twijfel bestaat"
+
+  sources:
+    - name: "BELASTING_ADRES"
+      description: "Adres bekend bij Belastingdienst voor belastingheffing"
+      type: "object"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      source_reference:
+        table: "belasting_adressen"
+        fields: ["postcode", "huisnummer", "straat", "woonplaats"]
+        select_on:
+          - name: "bsn"
+            description: "BSN van de belastingplichtige"
+            type: "string"
+            value: "$BSN"
+      legal_basis:
+        law: "Algemene wet inzake rijksbelastingen"
+        bwb_id: "BWBR0002320"
+        article: "53"
+        url: "https://wetten.overheid.nl/BWBR0002320/2024-01-01#HoofdstukVIII_Artikel53"
+        juriconnect: "jci1.3:c:BWBR0002320&artikel=53&z=2024-01-01&g=2024-01-01"
+        explanation: "Artikel 53 AWR verplicht opgave van woonadres aan Belastingdienst"
+
+    - name: "LANGDURIG_BUITENLAND"
+      description: "Persoon langdurig in buitenland volgens belastinggegevens"
+      type: "boolean"
+      temporal:
+        type: "period"
+        period_type: "continuous"
+      source_reference:
+        table: "belasting_verblijf"
+        field: "langdurig_afwezig"
+        select_on:
+          - name: "bsn"
+            description: "BSN van de belastingplichtige"
+            type: "string"
+            value: "$BSN"
+      legal_basis:
+        law: "Algemene wet inzake rijksbelastingen"
+        bwb_id: "BWBR0002320"
+        article: "4"
+        url: "https://wetten.overheid.nl/BWBR0002320/2024-01-01#HoofdstukII_Artikel4"
+        juriconnect: "jci1.3:c:BWBR0002320&artikel=4&z=2024-01-01&g=2024-01-01"
+        explanation: "Artikel 4 AWR bepaalt binnenlandse belastingplicht o.b.v. woonplaats"
+
+  output:
+    - name: "heeft_gerede_twijfel_adres"
+      description: "Of er gerede twijfel bestaat over juistheid adresgegevens"
+      type: "boolean"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Wet basisregistratie personen"
+        bwb_id: "BWBR0033715"
+        article: "2.34"
+        url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+        juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+        explanation: "Artikel 2.34 verplicht melding bij gerede twijfel over adresgegevens"
+
+    - name: "twijfel_reden"
+      description: "Reden van twijfel over adresgegevens"
+      type: "string"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.5_Artikel28"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28 Besluit BRP regelt de terugmeldvoorziening en vereist onderbouwing"
+
+  definitions:
+    TWIJFEL_ADRES_AFWIJKING: "Adres bij Belastingdienst wijkt af van BRP"
+    TWIJFEL_LANGDURIG_AFWEZIG: "Persoon langdurig in buitenland, mogelijk geen ingezetene"
+
+requirements:
+  - all:
+      - subject: "$BSN"
+        operation: NOT_NULL
+      - subject: "$ADRES"
+        operation: NOT_NULL
+
+actions:
+  - output: "heeft_gerede_twijfel_adres"
+    operation: OR
+    values:
+      # Reden 1: Adres wijkt af van belastingadres
+      - operation: NOT_EQUALS
+        values:
+          - "$ADRES"
+          - "$BELASTING_ADRES"
+        legal_basis:
+          law: "Wet basisregistratie personen"
+          bwb_id: "BWBR0033715"
+          article: "2.34"
+          url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+          juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+          explanation: "Afwijkend adres levert gerede twijfel op"
+      # Reden 2: Langdurig in buitenland
+      - subject: "$LANGDURIG_BUITENLAND"
+        operation: EQUALS
+        value: true
+        legal_basis:
+          law: "Wet basisregistratie personen"
+          bwb_id: "BWBR0033715"
+          article: "2.34"
+          url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+          juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+          explanation: "Langdurig verblijf buitenland levert gerede twijfel over ingezetenschap"
+    legal_basis:
+      law: "Wet basisregistratie personen"
+      bwb_id: "BWBR0033715"
+      article: "2.34"
+      url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+      juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+      explanation: "Artikel 2.34 verplicht melding bij gerede twijfel"
+
+  - output: "twijfel_reden"
+    operation: IF
+    conditions:
+      - test:
+          operation: NOT_EQUALS
+          values:
+            - "$ADRES"
+            - "$BELASTING_ADRES"
+        then: "$TWIJFEL_ADRES_AFWIJKING"
+      - test:
+          subject: "$LANGDURIG_BUITENLAND"
+          operation: EQUALS
+          value: true
+        then: "$TWIJFEL_LANGDURIG_AFWEZIG"
+      - else: null
+    legal_basis:
+      law: "Besluit basisregistratie personen"
+      bwb_id: "BWBR0034306"
+      article: "28"
+      url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.5_Artikel28"
+      juriconnect: "jci1.3:c:BWBR0034306&artikel=28&z=2024-04-01&g=2024-04-01"
+      explanation: "Artikel 28 vereist specificatie van reden bij terugmelding"

--- a/laws/wet_brp/terugmelding/CJIB-2023-05-15.yaml
+++ b/laws/wet_brp/terugmelding/CJIB-2023-05-15.yaml
@@ -1,0 +1,180 @@
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: 8e3f7a2c-4d9b-4e1f-9a6c-2f7e4d8a3b5c
+name: BRP Terugmeldplicht CJIB
+law: wet_brp
+law_type: "FORMELE_WET"
+legal_character: "BESCHIKKING"
+decision_type: "ANDERE_HANDELING"
+valid_from: 2023-05-15
+service: "CJIB"
+legal_basis:
+  law: "Wet basisregistratie personen"
+  bwb_id: "BWBR0033715"
+  article: "2.34"
+  url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+  juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+  explanation: "Artikel 2.34 verplicht bestuursorganen gerede twijfel over BRP-gegevens te melden via de terugmeldvoorziening"
+description: >
+  Het Centraal Justitieel Incassobureau (CJIB) heeft een wettelijke verplichting om twijfel
+  over de juistheid van adresgegevens in de BRP te melden. Dit gebeurt via de Terugmeldvoorziening
+  (TMV) naar gemeenten. CJIB ontdekt afwijkingen vooral via het OBR-profiel (Onbestelbaar Retour)
+  waarbij post onbestelbaar retour komt.
+
+references:
+  - law: "Wet BRP"
+    article: "2.34"
+    url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+  - law: "Besluit BRP"
+    article: "28"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.5_Artikel28"
+
+properties:
+  parameters:
+    - name: "BSN"
+      description: "BSN van de persoon"
+      type: "string"
+      required: true
+      legal_basis:
+        law: "Wet basisregistratie personen"
+        bwb_id: "BWBR0033715"
+        article: "2.34"
+        url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+        juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+        explanation: "Artikel 2.34 vereist identificatie van persoon bij terugmelding"
+
+    - name: "ADRES"
+      description: "Adresgegevens die mogelijk onjuist zijn"
+      type: "object"
+      required: true
+      legal_basis:
+        law: "Wet basisregistratie personen"
+        bwb_id: "BWBR0033715"
+        article: "2.34"
+        url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+        juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+        explanation: "Artikel 2.34 vereist specificatie van het adresgegeven waarover twijfel bestaat"
+
+  sources:
+    - name: "POST_ONBESTELBAAR"
+      description: "Post aan dit adres is onbestelbaar retour gekomen"
+      type: "boolean"
+      temporal:
+        type: "period"
+        period_type: "continuous"
+      source_reference:
+        table: "cjib_post"
+        field: "onbestelbaar_retour"
+        select_on:
+          - name: "bsn"
+            description: "BSN van de persoon"
+            type: "string"
+            value: "$BSN"
+      legal_basis:
+        law: "Wet Mulder"
+        bwb_id: "BWBR0004581"
+        article: "4"
+        url: "https://wetten.overheid.nl/BWBR0004581/2024-01-01#Artikel4"
+        juriconnect: "jci1.3:c:BWBR0004581&artikel=4&z=2024-01-01&g=2024-01-01"
+        explanation: "Artikel 4 Wet Mulder bepaalt bevoegdheden CJIB bij inning geldboetes"
+
+    - name: "AANTAL_ONBESTELBAAR"
+      description: "Aantal keer dat post onbestelbaar retour is gekomen"
+      type: "number"
+      type_spec:
+        precision: 0
+        min: 0
+      temporal:
+        type: "period"
+        period_type: "year"
+      source_reference:
+        table: "cjib_post"
+        field: "aantal_onbestelbaar"
+        select_on:
+          - name: "bsn"
+            description: "BSN van de persoon"
+            type: "string"
+            value: "$BSN"
+      legal_basis:
+        law: "Wet Mulder"
+        bwb_id: "BWBR0004581"
+        article: "4"
+        url: "https://wetten.overheid.nl/BWBR0004581/2024-01-01#Artikel4"
+        juriconnect: "jci1.3:c:BWBR0004581&artikel=4&z=2024-01-01&g=2024-01-01"
+        explanation: "Artikel 4 Wet Mulder regelt werkzaamheden CJIB bij invordering"
+
+  output:
+    - name: "heeft_gerede_twijfel_adres"
+      description: "Of er gerede twijfel bestaat over juistheid adresgegevens"
+      type: "boolean"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Wet basisregistratie personen"
+        bwb_id: "BWBR0033715"
+        article: "2.34"
+        url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+        juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+        explanation: "Artikel 2.34 verplicht melding bij gerede twijfel over adresgegevens"
+
+    - name: "twijfel_reden"
+      description: "Reden van twijfel over adresgegevens"
+      type: "string"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.5_Artikel28"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28 Besluit BRP regelt de terugmeldvoorziening en vereist onderbouwing"
+
+  definitions:
+    TWIJFEL_OBR_ENKEL: "Post eenmalig onbestelbaar retour (OBR)"
+    TWIJFEL_OBR_HERHAALD: "Post meerdere keren onbestelbaar retour (OBR)"
+    OBR_DREMPEL_HERHAALD: 2
+
+requirements:
+  - all:
+      - subject: "$BSN"
+        operation: NOT_NULL
+      - subject: "$ADRES"
+        operation: NOT_NULL
+
+actions:
+  - output: "heeft_gerede_twijfel_adres"
+    subject: "$POST_ONBESTELBAAR"
+    operation: EQUALS
+    value: true
+    legal_basis:
+      law: "Wet basisregistratie personen"
+      bwb_id: "BWBR0033715"
+      article: "2.34"
+      url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+      juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+      explanation: "Onbestelbare post levert gerede twijfel op over adresgegevens"
+
+  - output: "twijfel_reden"
+    operation: IF
+    conditions:
+      - test:
+          operation: GREATER_OR_EQUAL
+          values:
+            - "$AANTAL_ONBESTELBAAR"
+            - "$OBR_DREMPEL_HERHAALD"
+        then: "$TWIJFEL_OBR_HERHAALD"
+      - test:
+          subject: "$POST_ONBESTELBAAR"
+          operation: EQUALS
+          value: true
+        then: "$TWIJFEL_OBR_ENKEL"
+      - else: null
+    legal_basis:
+      law: "Besluit basisregistratie personen"
+      bwb_id: "BWBR0034306"
+      article: "28"
+      url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.5_Artikel28"
+      juriconnect: "jci1.3:c:BWBR0034306&artikel=28&z=2024-04-01&g=2024-04-01"
+      explanation: "Artikel 28 vereist specificatie van reden bij terugmelding"

--- a/laws/wet_brp/terugmelding/TOESLAGEN-2023-05-15.yaml
+++ b/laws/wet_brp/terugmelding/TOESLAGEN-2023-05-15.yaml
@@ -1,0 +1,198 @@
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: 5f9d3e7a-4c8b-4e1f-9a6c-3d7e8f2a5b4c
+name: BRP Terugmeldplicht Dienst Toeslagen
+law: wet_brp
+law_type: "FORMELE_WET"
+legal_character: "BESCHIKKING"
+decision_type: "ANDERE_HANDELING"
+valid_from: 2023-05-15
+service: "TOESLAGEN"
+legal_basis:
+  law: "Wet basisregistratie personen"
+  bwb_id: "BWBR0033715"
+  article: "2.34"
+  url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+  juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+  explanation: "Artikel 2.34 verplicht bestuursorganen gerede twijfel over BRP-gegevens te melden via de terugmeldvoorziening"
+description: >
+  Dienst Toeslagen heeft een wettelijke verplichting om twijfel over de juistheid van
+  adresgegevens in de BRP te melden. Dit gebeurt via de Terugmeldvoorziening (TMV) naar
+  gemeenten. Dienst Toeslagen ontdekt afwijkingen bij toekenning van toeslagen zoals
+  huurtoeslag, zorgtoeslag en kinderopvangtoeslag.
+
+references:
+  - law: "Wet BRP"
+    article: "2.34"
+    url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+  - law: "Besluit BRP"
+    article: "28"
+    url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.5_Artikel28"
+
+properties:
+  parameters:
+    - name: "BSN"
+      description: "BSN van de persoon"
+      type: "string"
+      required: true
+      legal_basis:
+        law: "Wet basisregistratie personen"
+        bwb_id: "BWBR0033715"
+        article: "2.34"
+        url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+        juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+        explanation: "Artikel 2.34 vereist identificatie van persoon bij terugmelding"
+
+    - name: "ADRES"
+      description: "Adresgegevens die mogelijk onjuist zijn"
+      type: "object"
+      required: true
+      legal_basis:
+        law: "Wet basisregistratie personen"
+        bwb_id: "BWBR0033715"
+        article: "2.34"
+        url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+        juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+        explanation: "Artikel 2.34 vereist specificatie van het adresgegeven waarover twijfel bestaat"
+
+  sources:
+    - name: "TOESLAG_ADRES"
+      description: "Adres bekend bij Dienst Toeslagen voor toeslagverstrekking"
+      type: "object"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      source_reference:
+        table: "toeslagen_adressen"
+        fields: ["postcode", "huisnummer", "straat", "woonplaats"]
+        select_on:
+          - name: "bsn"
+            description: "BSN van de toeslagontvanger"
+            type: "string"
+            value: "$BSN"
+      legal_basis:
+        law: "Algemene wet inkomensafhankelijke regelingen"
+        bwb_id: "BWBR0018472"
+        article: "7"
+        url: "https://wetten.overheid.nl/BWBR0018472/2024-01-01#Artikel7"
+        juriconnect: "jci1.3:c:BWBR0018472&artikel=7&z=2024-01-01&g=2024-01-01"
+        explanation: "Artikel 7 Awir verplicht opgave van adresgegevens voor toeslagverstrekking"
+
+    - name: "TOESLAGEN_ONDERZOEK"
+      description: "Uitkomst adresonderzoek door Dienst Toeslagen"
+      type: "object"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      source_reference:
+        table: "toeslagen_adresonderzoek"
+        fields: ["onderzoek_datum", "onderzoek_uitkomst", "adres_geverifieerd"]
+        select_on:
+          - name: "bsn"
+            description: "BSN van de toeslagontvanger"
+            type: "string"
+            value: "$BSN"
+      legal_basis:
+        law: "Algemene wet inkomensafhankelijke regelingen"
+        bwb_id: "BWBR0018472"
+        article: "18"
+        url: "https://wetten.overheid.nl/BWBR0018472/2024-01-01#Artikel18"
+        juriconnect: "jci1.3:c:BWBR0018472&artikel=18&z=2024-01-01&g=2024-01-01"
+        explanation: "Artikel 18 Awir bepaalt controle en onderzoek door Dienst Toeslagen"
+
+  output:
+    - name: "heeft_gerede_twijfel_adres"
+      description: "Of er gerede twijfel bestaat over juistheid adresgegevens"
+      type: "boolean"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Wet basisregistratie personen"
+        bwb_id: "BWBR0033715"
+        article: "2.34"
+        url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+        juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+        explanation: "Artikel 2.34 verplicht melding bij gerede twijfel over adresgegevens"
+
+    - name: "twijfel_reden"
+      description: "Reden van twijfel over adresgegevens"
+      type: "string"
+      temporal:
+        type: "point_in_time"
+        reference: "$calculation_date"
+      legal_basis:
+        law: "Besluit basisregistratie personen"
+        bwb_id: "BWBR0034306"
+        article: "28"
+        url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.5_Artikel28"
+        juriconnect: "jci1.3:c:BWBR0034306&artikel=28&z=2024-04-01&g=2024-04-01"
+        explanation: "Artikel 28 Besluit BRP regelt de terugmeldvoorziening en vereist onderbouwing"
+
+  definitions:
+    TWIJFEL_ADRES_AFWIJKING: "Adres bij Dienst Toeslagen wijkt af van BRP"
+    TWIJFEL_ONDERZOEK: "Adresonderzoek Toeslagen bevestigt adres niet"
+
+requirements:
+  - all:
+      - subject: "$BSN"
+        operation: NOT_NULL
+      - subject: "$ADRES"
+        operation: NOT_NULL
+
+actions:
+  - output: "heeft_gerede_twijfel_adres"
+    operation: OR
+    values:
+      # Reden 1: Adres wijkt af van toeslagadres
+      - operation: NOT_EQUALS
+        values:
+          - "$ADRES"
+          - "$TOESLAG_ADRES"
+        legal_basis:
+          law: "Wet basisregistratie personen"
+          bwb_id: "BWBR0033715"
+          article: "2.34"
+          url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+          juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+          explanation: "Afwijkend adres levert gerede twijfel op"
+      # Reden 2: Onderzoek kon adres niet bevestigen
+      - subject: "$TOESLAGEN_ONDERZOEK.adres_geverifieerd"
+        operation: EQUALS
+        value: false
+        legal_basis:
+          law: "Wet basisregistratie personen"
+          bwb_id: "BWBR0033715"
+          article: "2.34"
+          url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+          juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+          explanation: "Niet-geverifieerd adres levert gerede twijfel op"
+    legal_basis:
+      law: "Wet basisregistratie personen"
+      bwb_id: "BWBR0033715"
+      article: "2.34"
+      url: "https://wetten.overheid.nl/BWBR0033715/2023-05-15#Hoofdstuk2_Paragraaf2.5_Artikel2.34"
+      juriconnect: "jci1.3:c:BWBR0033715&artikel=2.34&z=2023-05-15&g=2023-05-15"
+      explanation: "Artikel 2.34 verplicht melding bij gerede twijfel"
+
+  - output: "twijfel_reden"
+    operation: IF
+    conditions:
+      - test:
+          operation: NOT_EQUALS
+          values:
+            - "$ADRES"
+            - "$TOESLAG_ADRES"
+        then: "$TWIJFEL_ADRES_AFWIJKING"
+      - test:
+          subject: "$TOESLAGEN_ONDERZOEK.adres_geverifieerd"
+          operation: EQUALS
+          value: false
+        then: "$TWIJFEL_ONDERZOEK"
+      - else: null
+    legal_basis:
+      law: "Besluit basisregistratie personen"
+      bwb_id: "BWBR0034306"
+      article: "28"
+      url: "https://wetten.overheid.nl/BWBR0034306/2024-04-01#Hoofdstuk2_Afdeling2.5_Artikel28"
+      juriconnect: "jci1.3:c:BWBR0034306&artikel=28&z=2024-04-01&g=2024-04-01"
+      explanation: "Artikel 28 vereist specificatie van reden bij terugmelding"


### PR DESCRIPTION
…w separation

Implement LAA according to Besluit BRP articles 28a-28g with realistic data sources based on actual practice rather than theoretical possibilities.

## New laws added:

### Wet BAG (laws/wet_bag/)
- KADASTER-2018-07-28.yaml: BAG data distribution
  - Outputs: gebruiksdoel, oppervlakte, status, is_woonfunctie
  - Legal basis: Wet basisregistratie adressen en gebouwen (BWBR0023466)

### BRP Terugmeldplicht (laws/wet_brp/terugmelding/)
- BELASTINGDIENST-2023-05-15.yaml: Tax authority feedback obligation
  - Detects: address discrepancies, long-term abroad
  - Legal basis: Wet BRP Art. 2.34, AWR Art. 53, 4

- TOESLAGEN-2023-05-15.yaml: Benefits service feedback obligation
  - Detects: address discrepancies, unverified addresses
  - Legal basis: Wet BRP Art. 2.34, Awir Art. 7, 18

- CJIB-2023-05-15.yaml: CJIB feedback obligation
  - Detects: undeliverable mail (OBR profile)
  - Legal basis: Wet BRP Art. 2.34, Wet Mulder Art. 4

### LAA coordination (laws/wet_brp/laa/)
- RvIG-2023-05-15.yaml: LAA signal generation and coordination
  - Uses service_references to: Belastingdienst, Toeslagen, CJIB, BAG, BRP
  - Implements: notification analysis + profile analysis
  - BSN parameter is optional (required for person-specific signals, optional for address-based profiles)
  - NO utility consumption data (allowed by law but not used in practice)
  - Legal basis: Besluit BRP Art. 28a-28g

## Key implementation decisions:

1. **Practice over theory**: Only implemented data sources actually used (Belastingdienst, Toeslagen, CJIB signals + BAG + BRP), not theoretical sources like utility consumption

2. **Proper service separation**: Each organization has its own YAML with correct legal basis:
   - Kadaster owns BAG data
   - Belastingdienst/Toeslagen/CJIB report address doubts
   - RvIG coordinates LAA using service_references

3. **Optional BSN parameter**: LAA supports two scenarios:
   - Address-based signals (profiles): only ADRES required
   - Person-based signals (notifications): both BSN and ADRES

4. **Service references**: LAA uses input fields with service_reference instead of direct source_reference, creating proper dependency chain

## Validation:
✅ All schema validations pass
✅ All service references have corresponding outputs ✅ All variables properly defined

## Documentation:
Added CLAUDE.md with comprehensive guidelines for converting Dutch laws to YAML, including research process, common mistakes, and best practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)