### PR TITLE
Fix Kindgebonden Budget ALO-kop citizen_relevance to prevent double counting

### DIFF
--- a/laws/wet_op_het_kindgebonden_budget/TOESLAGEN-2025-01-01.yaml
+++ b/laws/wet_op_het_kindgebonden_budget/TOESLAGEN-2025-01-01.yaml
@@ -280,7 +280,7 @@ properties:
       temporal:
         type: "period"
         period_type: "year"
-      citizen_relevance: primary
+      citizen_relevance: secondary
       legal_basis:
         law: "Wet op het kindgebonden budget"
         bwb_id: "BWBR0022751"


### PR DESCRIPTION
## Summary
- Change `alo_kop_bedrag` from `primary` to `secondary` citizen_relevance

## Problem
The ALO-kop (alleenstaande ouderkop) amount was marked as `citizen_relevance: primary`, causing it to be counted twice in the dashboard sorting algorithm in poc-machine-law. Since `alo_kop_bedrag` is already included in the `kindgebonden_budget_jaar` calculation, this resulted in incorrect sorting (€8,502 + €3,480 = €11,982 instead of €8,502).

## Solution
Mark `alo_kop_bedrag` as `secondary` so only the total `kindgebonden_budget_jaar` is used for sorting, while the ALO-kop amount remains available as supplementary information.

## Testing
- All existing tests still pass
- Dashboard sorting now correctly uses only the total kindgebonden budget amount