### PR TITLE
fix: Correct LAA law fields and make BSN optional in terugmelding

### DIFF
--- a/laws/wet_brp/laa/RvIG-2023-05-15.yaml
+++ b/laws/wet_brp/laa/RvIG-2023-05-15.yaml
@@ -1,7 +1,7 @@
 $id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 7f3e9a2b-5c4d-4e8f-9b1a-3d6c8f2e4a5b
 name: Landelijke Aanpak Adreskwaliteit (LAA)
-law: wet_brp
+law: wet_brp/laa
 law_type: "FORMELE_WET"
 legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
@@ -108,7 +108,7 @@ properties:
       type: "boolean"
       service_reference:
         service: "BELASTINGDIENST"
-        law: "wet_brp"
+        law: "wet_brp/terugmelding"
         field: "heeft_gerede_twijfel_adres"
         parameters:
           - name: "BSN"
@@ -128,7 +128,7 @@ properties:
       type: "boolean"
       service_reference:
         service: "TOESLAGEN"
-        law: "wet_brp"
+        law: "wet_brp/terugmelding"
         field: "heeft_gerede_twijfel_adres"
         parameters:
           - name: "BSN"
@@ -148,7 +148,7 @@ properties:
       type: "boolean"
       service_reference:
         service: "CJIB"
-        law: "wet_brp"
+        law: "wet_brp/terugmelding"
         field: "heeft_gerede_twijfel_adres"
         parameters:
           - name: "BSN"

--- a/laws/wet_brp/terugmelding/BELASTINGDIENST-2023-05-15.yaml
+++ b/laws/wet_brp/terugmelding/BELASTINGDIENST-2023-05-15.yaml
@@ -1,7 +1,7 @@
 $id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 2a5c7e9f-4d8b-4e6a-9c1f-7e4d2a8b5c3e
 name: BRP Terugmeldplicht Belastingdienst
-law: wet_brp
+law: wet_brp/terugmelding
 law_type: "FORMELE_WET"
 legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
@@ -31,9 +31,9 @@ references:
 properties:
   parameters:
     - name: "BSN"
-      description: "BSN van de persoon"
+      description: "BSN van de persoon (optioneel bij adresgerichte controles)"
       type: "string"
-      required: true
+      required: false
       legal_basis:
         law: "Wet basisregistratie personen"
         bwb_id: "BWBR0033715"
@@ -134,8 +134,6 @@ properties:
 
 requirements:
   - all:
-      - subject: "$BSN"
-        operation: NOT_NULL
       - subject: "$ADRES"
         operation: NOT_NULL
 

--- a/laws/wet_brp/terugmelding/CJIB-2023-05-15.yaml
+++ b/laws/wet_brp/terugmelding/CJIB-2023-05-15.yaml
@@ -1,7 +1,7 @@
 $id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 8e3f7a2c-4d9b-4e1f-9a6c-2f7e4d8a3b5c
 name: BRP Terugmeldplicht CJIB
-law: wet_brp
+law: wet_brp/terugmelding
 law_type: "FORMELE_WET"
 legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
@@ -31,9 +31,9 @@ references:
 properties:
   parameters:
     - name: "BSN"
-      description: "BSN van de persoon"
+      description: "BSN van de persoon (optioneel bij adresgerichte controles)"
       type: "string"
-      required: true
+      required: false
       legal_basis:
         law: "Wet basisregistratie personen"
         bwb_id: "BWBR0033715"
@@ -66,7 +66,7 @@ properties:
         field: "onbestelbaar_retour"
         select_on:
           - name: "bsn"
-            description: "BSN van de persoon"
+            description: "BSN van de persoon (optioneel bij adresgerichte controles)"
             type: "string"
             value: "$BSN"
       legal_basis:
@@ -91,7 +91,7 @@ properties:
         field: "aantal_onbestelbaar"
         select_on:
           - name: "bsn"
-            description: "BSN van de persoon"
+            description: "BSN van de persoon (optioneel bij adresgerichte controles)"
             type: "string"
             value: "$BSN"
       legal_basis:
@@ -138,8 +138,6 @@ properties:
 
 requirements:
   - all:
-      - subject: "$BSN"
-        operation: NOT_NULL
       - subject: "$ADRES"
         operation: NOT_NULL
 

--- a/laws/wet_brp/terugmelding/TOESLAGEN-2023-05-15.yaml
+++ b/laws/wet_brp/terugmelding/TOESLAGEN-2023-05-15.yaml
@@ -1,7 +1,7 @@
 $id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
 uuid: 5f9d3e7a-4c8b-4e1f-9a6c-3d7e8f2a5b4c
 name: BRP Terugmeldplicht Dienst Toeslagen
-law: wet_brp
+law: wet_brp/terugmelding
 law_type: "FORMELE_WET"
 legal_character: "BESCHIKKING"
 decision_type: "ANDERE_HANDELING"
@@ -31,9 +31,9 @@ references:
 properties:
   parameters:
     - name: "BSN"
-      description: "BSN van de persoon"
+      description: "BSN van de persoon (optioneel bij adresgerichte controles)"
       type: "string"
-      required: true
+      required: false
       legal_basis:
         law: "Wet basisregistratie personen"
         bwb_id: "BWBR0033715"
@@ -134,8 +134,6 @@ properties:
 
 requirements:
   - all:
-      - subject: "$BSN"
-        operation: NOT_NULL
       - subject: "$ADRES"
         operation: NOT_NULL
 


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in the LAA (Landelijke Aanpak Adreskwaliteit) implementation that prevent tests from passing.

## Changes
- **LAA YAML**: Update `law` field from `wet_brp` to `wet_brp/laa` to match directory structure
- **LAA YAML**: Update service_references to point to `wet_brp/terugmelding` instead of `wet_brp`
- **Terugmelding YAMLs** (BELASTINGDIENST, TOESLAGEN, CJIB):
  - Update `law` field from `wet_brp` to `wet_brp/terugmelding`
  - Change BSN parameter from `required: true` to `required: false`
  - Remove BSN from requirements section (only ADRES should be required)

## Rationale
The law paths must match the directory structure for the engine to correctly resolve service references and dependencies. Additionally, BSN should be optional in terugmelding YAMLs to support profiel scenarios that work without BSN.

## Test Results
With these fixes, all 68 scenarios (including 8 LAA scenarios) pass successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>