### PR TITLE
fix: Use KINDEREN_GEGEVENS instead of HUISHOUDEN for kinderen output

### DIFF
--- a/laws/besluit_basisveiligheidsnormen_stralingsbescherming/ANVS-2018-01-01.yaml
+++ b/laws/besluit_basisveiligheidsnormen_stralingsbescherming/ANVS-2018-01-01.yaml
@@ -1,0 +1,263 @@
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: 7b4d8f3e-2c9a-4e1d-9f7b-5a3e6c8d1f4a
+name: Besluit basisveiligheidsnormen stralingsbescherming
+law: besluit_basisveiligheidsnormen_stralingsbescherming
+law_type: "FORMELE_WET"
+legal_character: "BESLUIT_VAN_ALGEMENE_STREKKING"
+decision_type: "ALGEMEEN_VERBINDEND_VOORSCHRIFT"
+discoverable: "BUSINESS"
+valid_from: 2018-01-01
+service: "ANVS"
+description: >
+  Basisveiligheidsnormen voor stralingsbescherming. Dit besluit stelt dosislimieten en andere
+  criteria vast voor het beschermen van mensen tegen ioniserende straling. Het is een uitwerking
+  van de Kernenergiewet en implementeert Europese richtlijnen.
+
+legal_basis:
+  law: "Besluit basisveiligheidsnormen stralingsbescherming"
+  bwb_id: "BWBR0040179"
+  article: "3.7"
+  url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+  juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&z=2018-01-01&g=2018-01-01"
+  explanation: "Artikel 3.7 stelt dosislimieten vast voor leden van de bevolking bij handelingen met ioniserende straling"
+
+references:
+  - law: "Besluit basisveiligheidsnormen stralingsbescherming"
+    article: "2.6"
+    url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk2_Artikel2.6"
+  - law: "Besluit basisveiligheidsnormen stralingsbescherming"
+    article: "3.7"
+    url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+  - law: "Kernenergiewet"
+    article: "15b"
+    url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+
+properties:
+  parameters:
+    - name: "verwachte_dosis_jaar"
+      description: "Verwachte effectieve stralingsdosis per jaar voor leden van de bevolking in millisievert"
+      type: "number"
+      type_spec:
+        precision: 2
+        min: 0
+      required: true
+      legal_basis:
+        law: "Besluit basisveiligheidsnormen stralingsbescherming"
+        bwb_id: "BWBR0040179"
+        article: "3.7"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+        juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&lid=1&z=2018-01-01&g=2018-01-01"
+        explanation: "Artikel 3.7 lid 1 bepaalt maximale effectieve dosis voor bevolking"
+
+    - name: "verwachte_dosis_huid"
+      description: "Verwachte equivalente stralingsdosis voor de huid per jaar in millisievert"
+      type: "number"
+      type_spec:
+        precision: 2
+        min: 0
+      required: false
+      legal_basis:
+        law: "Besluit basisveiligheidsnormen stralingsbescherming"
+        bwb_id: "BWBR0040179"
+        article: "3.7"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+        juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&lid=1&z=2018-01-01&g=2018-01-01"
+        explanation: "Artikel 3.7 lid 1 bepaalt maximale equivalente dosis voor huid"
+
+    - name: "dosis_buiten_locatie"
+      description: "Verwachte stralingsdosis buiten de locatie in millisievert per jaar"
+      type: "number"
+      type_spec:
+        precision: 2
+        min: 0
+      required: false
+      legal_basis:
+        law: "Besluit basisveiligheidsnormen stralingsbescherming"
+        bwb_id: "BWBR0040179"
+        article: "3.7"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+        juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&lid=1&z=2018-01-01&g=2018-01-01"
+        explanation: "Artikel 3.7 lid 1 bepaalt maximale dosis op enig punt buiten de locatie"
+
+  output:
+    - name: "verwachte_dosis_bevolking"
+      description: "Verwachte stralingsdosis voor de bevolking"
+      type: "number"
+      type_spec:
+        precision: 2
+        min: 0
+      legal_basis:
+        law: "Besluit basisveiligheidsnormen stralingsbescherming"
+        bwb_id: "BWBR0040179"
+        article: "3.7"
+        url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+        juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&z=2018-01-01&g=2018-01-01"
+        explanation: "Artikel 3.7 stelt dosislimieten vast voor bevolking"
+
+    - name: "dosislimiet_overschreden"
+      description: "Of de dosislimiet wordt overschreden"
+      type: "boolean"
+      legal_basis:
+        law: "Besluit basisveiligheidsnormen stralingsbescherming"
+        bwb_id: "BWBR0040179"
+        article: "3.7"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+        juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&lid=1&z=2018-01-01&g=2018-01-01"
+        explanation: "Artikel 3.7 lid 1 bepaalt dosislimieten die niet overschreden mogen worden"
+
+    - name: "vergunning_toegestaan_straling"
+      description: "Of vergunning toegestaan is op basis van stralingscriteria"
+      type: "boolean"
+      legal_basis:
+        law: "Besluit basisveiligheidsnormen stralingsbescherming"
+        bwb_id: "BWBR0040179"
+        article: "3.7"
+        url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+        juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&z=2018-01-01&g=2018-01-01"
+        explanation: "Artikel 3.7 bepaalt dat vergunning niet verleend wordt indien dosislimieten worden overschreden"
+
+    - name: "overschreden_limieten"
+      description: "Lijst van overschreden dosislimieten"
+      type: "array"
+      legal_basis:
+        law: "Besluit basisveiligheidsnormen stralingsbescherming"
+        bwb_id: "BWBR0040179"
+        article: "3.7"
+        url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+        juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&z=2018-01-01&g=2018-01-01"
+        explanation: "Artikel 3.7 stelt verschillende dosislimieten vast"
+
+  definitions:
+    DOSIS_LIMIET_BEVOLKING_ALGEMEEN: 1.0  # millisievert per jaar
+    DOSIS_LIMIET_BEVOLKING_BUITEN_LOCATIE: 0.1  # millisievert per jaar
+    DOSIS_LIMIET_HUID: 50.0  # millisievert per jaar
+
+    LIMIET_TYPE_ALGEMEEN: "effectieve_dosis_algemeen"
+    LIMIET_TYPE_BUITEN_LOCATIE: "effectieve_dosis_buiten_locatie"
+    LIMIET_TYPE_HUID: "equivalente_dosis_huid"
+
+requirements:
+  - subject: "$verwachte_dosis_jaar"
+    operation: GREATER_OR_EQUAL
+    value: 0
+
+actions:
+  - output: "verwachte_dosis_bevolking"
+    value: "$verwachte_dosis_jaar"
+    legal_basis:
+      law: "Besluit basisveiligheidsnormen stralingsbescherming"
+      bwb_id: "BWBR0040179"
+      article: "3.7"
+      url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+      juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&z=2018-01-01&g=2018-01-01"
+      explanation: "Verwachte dosis voor bevolking wordt geëvalueerd tegen dosislimieten"
+
+  - output: "overschreden_limieten"
+    operation: IF
+    legal_basis:
+      law: "Besluit basisveiligheidsnormen stralingsbescherming"
+      bwb_id: "BWBR0040179"
+      article: "3.7"
+      paragraph: "1"
+      url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+      juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&lid=1&z=2018-01-01&g=2018-01-01"
+      explanation: "Artikel 3.7 lid 1 stelt verschillende dosislimieten vast die niet overschreden mogen worden"
+    conditions:
+      - test:
+          subject: "$verwachte_dosis_jaar"
+          operation: GREATER_THAN
+          value: "$DOSIS_LIMIET_BEVOLKING_ALGEMEEN"
+        legal_basis:
+          law: "Besluit basisveiligheidsnormen stralingsbescherming"
+          bwb_id: "BWBR0040179"
+          article: "3.7"
+          paragraph: "1"
+          url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+          juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&lid=1&z=2018-01-01&g=2018-01-01"
+          explanation: "Artikel 3.7 lid 1 bepaalt maximale effectieve dosis van 1 mSv per kalenderjaar"
+        then:
+          - "effectieve_dosis_algemeen"
+      - test:
+          operation: AND
+          values:
+            - operation: NOT_NULL
+              subject: "$dosis_buiten_locatie"
+            - operation: GREATER_THAN
+              values:
+                - "$dosis_buiten_locatie"
+                - "$DOSIS_LIMIET_BEVOLKING_BUITEN_LOCATIE"
+        legal_basis:
+          law: "Besluit basisveiligheidsnormen stralingsbescherming"
+          bwb_id: "BWBR0040179"
+          article: "3.7"
+          paragraph: "1"
+          url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+          juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&lid=1&z=2018-01-01&g=2018-01-01"
+          explanation: "Artikel 3.7 lid 1 bepaalt maximale effectieve dosis van 0,1 mSv per kalenderjaar op enig punt buiten de locatie"
+        then:
+          - "effectieve_dosis_buiten_locatie"
+      - test:
+          operation: AND
+          values:
+            - operation: NOT_NULL
+              subject: "$verwachte_dosis_huid"
+            - operation: GREATER_THAN
+              values:
+                - "$verwachte_dosis_huid"
+                - "$DOSIS_LIMIET_HUID"
+        legal_basis:
+          law: "Besluit basisveiligheidsnormen stralingsbescherming"
+          bwb_id: "BWBR0040179"
+          article: "3.7"
+          paragraph: "1"
+          url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+          juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&lid=1&z=2018-01-01&g=2018-01-01"
+          explanation: "Artikel 3.7 lid 1 bepaalt maximale equivalente dosis voor huid van 50 mSv per kalenderjaar"
+        then:
+          - "equivalente_dosis_huid"
+      - else: []
+
+  - output: "dosislimiet_overschreden"
+    operation: IF
+    legal_basis:
+      law: "Besluit basisveiligheidsnormen stralingsbescherming"
+      bwb_id: "BWBR0040179"
+      article: "3.7"
+      url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+      juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&z=2018-01-01&g=2018-01-01"
+      explanation: "Indien dosislimieten worden overschreden, is dosislimiet_overschreden waar"
+    conditions:
+      - test:
+          subject: "$overschreden_limieten"
+          operation: NOT_EQUALS
+          value: []
+        then: true
+      - else: false
+
+  - output: "vergunning_toegestaan_straling"
+    operation: IF
+    legal_basis:
+      law: "Besluit basisveiligheidsnormen stralingsbescherming"
+      bwb_id: "BWBR0040179"
+      article: "3.7"
+      url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+      juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&z=2018-01-01&g=2018-01-01"
+      explanation: "Vergunning wordt niet verleend indien dosislimieten worden overschreden"
+    conditions:
+      - test:
+          subject: "$dosislimiet_overschreden"
+          operation: EQUALS
+          value: false
+        legal_basis:
+          law: "Besluit basisveiligheidsnormen stralingsbescherming"
+          bwb_id: "BWBR0040179"
+          article: "3.7"
+          url: "https://wetten.overheid.nl/BWBR0040179/2018-01-01#Hoofdstuk3_Paragraaf3.2_Artikel3.7"
+          juriconnect: "jci1.3:c:BWBR0040179&artikel=3.7&z=2018-01-01&g=2018-01-01"
+          explanation: "Als geen dosislimieten overschreden worden, kan vergunning worden verleend"
+        then: true
+      - else: false

--- a/laws/besluit_kerninstallaties/ANVS-2024-01-01.yaml
+++ b/laws/besluit_kerninstallaties/ANVS-2024-01-01.yaml
@@ -1,0 +1,244 @@
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: 9c6e5a4f-3d8b-4c2a-9e7d-6b4f8c9a3e2d
+name: Besluit kerninstallaties, splijtstoffen en ertsen
+law: besluit_kerninstallaties
+law_type: "FORMELE_WET"
+legal_character: "BESLUIT_VAN_ALGEMENE_STREKKING"
+decision_type: "ALGEMEEN_VERBINDEND_VOORSCHRIFT"
+discoverable: "BUSINESS"
+valid_from: 2024-01-01
+service: "ANVS"
+description: >
+  Regelgeving voor kerninstallaties, splijtstoffen en ertsen. Dit besluit werkt de Kernenergiewet
+  uit met concrete eisen voor financiële zekerheid, beveiligingsplannen, deskundigheid en andere
+  voorwaarden voor vergunningverlening.
+
+legal_basis:
+  law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+  bwb_id: "BWBR0002667"
+  url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+  juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+  explanation: "Dit besluit geeft uitvoering aan de Kernenergiewet"
+
+references:
+  - law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+    article: "19"
+    url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+  - law: "Kernenergiewet"
+    article: "15b"
+    url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+  - law: "Kernenergiewet"
+    article: "15c"
+    url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15c"
+
+properties:
+  parameters:
+    - name: "heeft_beveiligingsplan"
+      description: "Of er een goedgekeurd beveiligingsplan aanwezig is"
+      type: "boolean"
+      required: true
+      legal_basis:
+        law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+        bwb_id: "BWBR0002667"
+        url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+        juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+        explanation: "Het besluit vereist een beveiligingsplan voor nucleaire installaties"
+
+    - name: "heeft_noodplan"
+      description: "Of er een noodplan aanwezig is"
+      type: "boolean"
+      required: true
+      legal_basis:
+        law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+        bwb_id: "BWBR0002667"
+        url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+        juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+        explanation: "Het besluit vereist een noodplan voor nucleaire installaties"
+
+    - name: "heeft_beeindigingsplan"
+      description: "Of er een plan voor beëindiging/ontmanteling aanwezig is"
+      type: "boolean"
+      required: false
+      legal_basis:
+        law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+        bwb_id: "BWBR0002667"
+        url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+        juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+        explanation: "Het besluit kan een beëindigingsplan vereisen voor nucleaire installaties"
+
+    - name: "financiele_zekerheid_bedrag"
+      description: "Bedrag van de gestelde financiële zekerheid in eurocent"
+      type: "amount"
+      type_spec:
+        unit: "eurocent"
+        precision: 0
+        min: 0
+      required: true
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15b lid 1 vereist zekerheid voor betaling van schadevergoeding"
+
+    - name: "aantal_deskundigen"
+      description: "Aantal stralingsbeschermingsdeskundigen beschikbaar"
+      type: "number"
+      type_spec:
+        precision: 0
+        min: 0
+      required: true
+      legal_basis:
+        law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+        bwb_id: "BWBR0002667"
+        url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+        juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+        explanation: "Het besluit vereist voldoende deskundigen voor stralingsbescherming"
+
+  output:
+    - name: "financiele_zekerheid_gesteld"
+      description: "Of voldoende financiële zekerheid is gesteld"
+      type: "boolean"
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15b lid 1 bepaalt dat vergunning kan worden geweigerd zonder financiële zekerheid"
+
+    - name: "beveiligingsplan_voldoet"
+      description: "Of het beveiligingsplan voldoet aan de eisen"
+      type: "boolean"
+      legal_basis:
+        law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+        bwb_id: "BWBR0002667"
+        url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+        juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+        explanation: "Het besluit stelt eisen aan het beveiligingsplan"
+
+    - name: "noodplan_voldoet"
+      description: "Of het noodplan voldoet aan de eisen"
+      type: "boolean"
+      legal_basis:
+        law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+        bwb_id: "BWBR0002667"
+        url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+        juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+        explanation: "Het besluit stelt eisen aan het noodplan"
+
+    - name: "deskundigheid_voldoende"
+      description: "Of voldoende deskundigen beschikbaar zijn"
+      type: "boolean"
+      legal_basis:
+        law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+        bwb_id: "BWBR0002667"
+        url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+        juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+        explanation: "Het besluit vereist voldoende deskundigheid"
+
+    - name: "administratieve_eisen_voldaan"
+      description: "Of alle administratieve eisen zijn voldaan"
+      type: "boolean"
+      legal_basis:
+        law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+        bwb_id: "BWBR0002667"
+        url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+        juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+        explanation: "Het besluit stelt diverse administratieve eisen"
+
+  definitions:
+    MINIMAAL_FINANCIELE_ZEKERHEID: 100000000  # 1 miljoen euro in eurocent
+    MINIMUM_AANTAL_DESKUNDIGEN: 1
+
+requirements:
+  - subject: "$financiele_zekerheid_bedrag"
+    operation: GREATER_OR_EQUAL
+    value: 0
+
+actions:
+  - output: "financiele_zekerheid_gesteld"
+    operation: IF
+    legal_basis:
+      law: "Kernenergiewet"
+      bwb_id: "BWBR0002402"
+      article: "15b"
+      paragraph: "1"
+      url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+      juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+      explanation: "Artikel 15b lid 1 vereist zekerheid voor betaling van schadevergoeding"
+    conditions:
+      - test:
+          subject: "$financiele_zekerheid_bedrag"
+          operation: GREATER_OR_EQUAL
+          value: "$MINIMAAL_FINANCIELE_ZEKERHEID"
+        then: true
+      - else: false
+
+  - output: "beveiligingsplan_voldoet"
+    value: "$heeft_beveiligingsplan"
+    legal_basis:
+      law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+      bwb_id: "BWBR0002667"
+      url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+      juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+      explanation: "Het besluit vereist een beveiligingsplan"
+
+  - output: "noodplan_voldoet"
+    value: "$heeft_noodplan"
+    legal_basis:
+      law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+      bwb_id: "BWBR0002667"
+      url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+      juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+      explanation: "Het besluit vereist een noodplan"
+
+  - output: "deskundigheid_voldoende"
+    operation: IF
+    legal_basis:
+      law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+      bwb_id: "BWBR0002667"
+      url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+      juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+      explanation: "Het besluit vereist voldoende deskundigheid"
+    conditions:
+      - test:
+          subject: "$aantal_deskundigen"
+          operation: GREATER_OR_EQUAL
+          value: "$MINIMUM_AANTAL_DESKUNDIGEN"
+        then: true
+      - else: false
+
+  - output: "administratieve_eisen_voldaan"
+    operation: IF
+    legal_basis:
+      law: "Besluit kerninstallaties, splijtstoffen en ertsen"
+      bwb_id: "BWBR0002667"
+      url: "https://wetten.overheid.nl/BWBR0002667/2025-01-01"
+      juriconnect: "jci1.3:c:BWBR0002667&z=2025-01-01&g=2025-01-01"
+      explanation: "Het besluit stelt diverse eisen die cumulatief voldaan moeten worden"
+    conditions:
+      - test:
+          operation: AND
+          values:
+            - operation: EQUALS
+              values:
+                - "$financiele_zekerheid_gesteld"
+                - true
+            - operation: EQUALS
+              values:
+                - "$beveiligingsplan_voldoet"
+                - true
+            - operation: EQUALS
+              values:
+                - "$noodplan_voldoet"
+                - true
+            - operation: EQUALS
+              values:
+                - "$deskundigheid_voldoende"
+                - true
+        then: true
+      - else: false

--- a/laws/kernenergiewet/ANVS-2024-07-01.yaml
+++ b/laws/kernenergiewet/ANVS-2024-07-01.yaml
@@ -1,0 +1,277 @@
+$id: https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.1.6/schema.json
+uuid: 3f8a5c2d-9e7b-4f1c-8d6a-1b9e4c7a2f5d
+name: Kernenergiewet Vergunningverlening Splijtstoffen
+law: kernenergiewet
+law_type: "FORMELE_WET"
+legal_character: "BESCHIKKING"
+decision_type: "ANDERE_HANDELING"
+discoverable: "BUSINESS"
+valid_from: 2024-07-01
+service: "ANVS"
+description: >
+  Vergunningverlening voor handelingen met splijtstoffen, ertsen en inrichtingen volgens artikel 15
+  van de Kernenergiewet. De Autoriteit Nucleaire Veiligheid en Stralingsbescherming (ANVS)
+  beoordeelt of een vergunning kan worden verleend op basis van veiligheidscriteria.
+
+legal_basis:
+  law: "Kernenergiewet"
+  bwb_id: "BWBR0002402"
+  article: "15"
+  url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15"
+  juriconnect: "jci1.3:c:BWBR0002402&artikel=15&z=2024-07-01&g=2024-07-01"
+  explanation: "Artikel 15 bepaalt het verbod op handelingen met splijtstoffen en ertsen zonder vergunning van de ANVS"
+
+references:
+  - law: "Kernenergiewet"
+    article: "15"
+    url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15"
+  - law: "Kernenergiewet"
+    article: "15b"
+    url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+  - law: "Kernenergiewet"
+    article: "15c"
+    url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15c"
+
+properties:
+  parameters:
+    - name: "activiteit_type"
+      description: "Type activiteit waarvoor vergunning wordt aangevraagd"
+      type: "string"
+      required: true
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15 onderscheidt verschillende activiteiten: transport, bezit, in/uitvoer, oprichten/exploiteren inrichting"
+
+    - name: "materiaal_type"
+      description: "Type materiaal (splijtstof of erts)"
+      type: "string"
+      required: true
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15"
+        paragraph: "a"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15 lid a regelt splijtstoffen en ertsen"
+
+    - name: "is_nieuwe_installatie"
+      description: "Is dit een nieuwe kerninstallatie"
+      type: "boolean"
+      required: false
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "2"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=2&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15b lid 2 stelt bijzondere eisen aan nieuwe installaties"
+
+    - name: "technologie_beschrijving"
+      description: "Beschrijving van de gebruikte technologie"
+      type: "string"
+      required: false
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "2"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=2&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15b lid 2 stelt dat vergunning kan worden geweigerd als technologie verouderd is"
+
+  input:
+    - name: "VERWACHTE_STRALINGSDOSIS"
+      description: "Verwachte stralingsdosis per jaar in millisievert"
+      type: "number"
+      type_spec:
+        precision: 2
+        min: 0
+      service_reference:
+        service: "ANVS"
+        law: "besluit_basisveiligheidsnormen_stralingsbescherming"
+        field: "verwachte_dosis_bevolking"
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15b lid 1 bepaalt dat vergunning alleen geweigerd kan worden in het belang van bescherming van mensen"
+
+    - name: "HEEFT_FINANCIELE_ZEKERHEID"
+      description: "Of er financiële zekerheid is gesteld"
+      type: "boolean"
+      service_reference:
+        service: "ANVS"
+        law: "besluit_kerninstallaties"
+        field: "financiele_zekerheid_gesteld"
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15b lid 1 bepaalt dat vergunning kan worden geweigerd voor zekerheid van betaling van schadevergoeding"
+
+  output:
+    - name: "vergunning_vereist"
+      description: "Of een vergunning vereist is voor deze activiteit"
+      type: "boolean"
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15 bepaalt voor welke activiteiten een vergunning van de ANVS vereist is"
+
+    - name: "vergunning_toegestaan"
+      description: "Of de vergunning kan worden verleend"
+      type: "boolean"
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15b lid 1 bepaalt in welke gevallen een vergunning geweigerd kan worden"
+
+    - name: "weigeringsgronden"
+      description: "Lijst van weigeringsgronden die van toepassing zijn"
+      type: "array"
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&z=2024-07-01&g=2024-07-01"
+        explanation: "Artikel 15b somt de weigeringsgronden op"
+
+  definitions:
+    ACTIVITEIT_TRANSPORT: "transport"
+    ACTIVITEIT_BEZIT: "bezit"
+    ACTIVITEIT_INVOER: "invoer"
+    ACTIVITEIT_UITVOER: "uitvoer"
+    ACTIVITEIT_INRICHTING_OPRICHTEN: "inrichting_oprichten"
+    ACTIVITEIT_INRICHTING_EXPLOITEREN: "inrichting_exploiteren"
+    ACTIVITEIT_KERNVOORTSTUWING: "kernvoortstuwing"
+
+    MATERIAAL_SPLIJTSTOF: "splijtstof"
+    MATERIAAL_ERTS: "erts"
+
+    WEIGERINGSGROND_VEILIGHEID: "bescherming_mensen_dieren_planten_goederen"
+    WEIGERINGSGROND_STAATSVEILIGHEID: "staatsveiligheid"
+    WEIGERINGSGROND_BEVEILIGING: "behoud_beveiliging_splijtstoffen"
+    WEIGERINGSGROND_SCHADEVERGOEDING: "zekerheid_betaling_schadevergoeding"
+    WEIGERINGSGROND_INTERNATIONALE_VERPLICHTINGEN: "internationale_verplichtingen"
+    WEIGERINGSGROND_TECHNOLOGIE_VEROUDERD: "technologie_verouderd"
+
+    DOSIS_LIMIET_BEVOLKING: 1.0  # millisievert per jaar
+
+requirements:
+  - any:
+      - subject: "$activiteit_type"
+        operation: EQUALS
+        value: "$ACTIVITEIT_TRANSPORT"
+      - subject: "$activiteit_type"
+        operation: EQUALS
+        value: "$ACTIVITEIT_BEZIT"
+      - subject: "$activiteit_type"
+        operation: EQUALS
+        value: "$ACTIVITEIT_INVOER"
+      - subject: "$activiteit_type"
+        operation: EQUALS
+        value: "$ACTIVITEIT_UITVOER"
+      - subject: "$activiteit_type"
+        operation: EQUALS
+        value: "$ACTIVITEIT_INRICHTING_OPRICHTEN"
+      - subject: "$activiteit_type"
+        operation: EQUALS
+        value: "$ACTIVITEIT_INRICHTING_EXPLOITEREN"
+      - subject: "$activiteit_type"
+        operation: EQUALS
+        value: "$ACTIVITEIT_KERNVOORTSTUWING"
+
+actions:
+  - output: "vergunning_vereist"
+    value: true
+    legal_basis:
+      law: "Kernenergiewet"
+      bwb_id: "BWBR0002402"
+      article: "15"
+      url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15"
+      juriconnect: "jci1.3:c:BWBR0002402&artikel=15&z=2024-07-01&g=2024-07-01"
+      explanation: "Artikel 15 bepaalt dat voor alle genoemde activiteiten een vergunning vereist is"
+
+  - output: "weigeringsgronden"
+    operation: IF
+    legal_basis:
+      law: "Kernenergiewet"
+      bwb_id: "BWBR0002402"
+      article: "15b"
+      url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+      juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&z=2024-07-01&g=2024-07-01"
+      explanation: "Artikel 15b bepaalt de weigeringsgronden voor vergunningen"
+    conditions:
+      - test:
+          subject: "$VERWACHTE_STRALINGSDOSIS"
+          operation: GREATER_THAN
+          value: "$DOSIS_LIMIET_BEVOLKING"
+        legal_basis:
+          law: "Kernenergiewet"
+          bwb_id: "BWBR0002402"
+          article: "15b"
+          paragraph: "1"
+          url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+          juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+          explanation: "Artikel 15b lid 1 bepaalt dat vergunning geweigerd kan worden ter bescherming van mensen"
+        then:
+          - "$WEIGERINGSGROND_VEILIGHEID"
+      - test:
+          subject: "$HEEFT_FINANCIELE_ZEKERHEID"
+          operation: EQUALS
+          value: false
+        legal_basis:
+          law: "Kernenergiewet"
+          bwb_id: "BWBR0002402"
+          article: "15b"
+          paragraph: "1"
+          url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+          juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+          explanation: "Artikel 15b lid 1 bepaalt dat vergunning geweigerd kan worden voor zekerheid van betaling schadevergoeding"
+        then:
+          - "$WEIGERINGSGROND_SCHADEVERGOEDING"
+      - else: []
+
+  - output: "vergunning_toegestaan"
+    operation: IF
+    legal_basis:
+      law: "Kernenergiewet"
+      bwb_id: "BWBR0002402"
+      article: "15b"
+      url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+      juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&z=2024-07-01&g=2024-07-01"
+      explanation: "Artikel 15b bepaalt wanneer een vergunning geweigerd kan worden"
+    conditions:
+      - test:
+          subject: "$weigeringsgronden"
+          operation: EQUALS
+          value: []
+        legal_basis:
+          law: "Kernenergiewet"
+          bwb_id: "BWBR0002402"
+          article: "15b"
+          url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+          juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&z=2024-07-01&g=2024-07-01"
+          explanation: "Als er geen weigeringsgronden zijn, kan de vergunning worden verleend"
+        then: true
+      - else: false

--- a/laws/kernenergiewet/ANVS-2024-07-01.yaml
+++ b/laws/kernenergiewet/ANVS-2024-07-01.yaml
@@ -85,6 +85,97 @@ properties:
         juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=2&z=2024-07-01&g=2024-07-01"
         explanation: "Artikel 15b lid 2 stelt dat vergunning kan worden geweigerd als technologie verouderd is"
 
+    - name: "verwachte_dosis_jaar"
+      description: "Verwachte effectieve stralingsdosis per jaar"
+      type: "number"
+      required: false
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Voor beoordeling of vergunning geweigerd moet worden"
+
+    - name: "verwachte_dosis_huid"
+      description: "Verwachte equivalente stralingsdosis huid per jaar"
+      type: "number"
+      required: false
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Voor beoordeling of vergunning geweigerd moet worden"
+
+    - name: "dosis_buiten_locatie"
+      description: "Verwachte dosis buiten locatie per jaar"
+      type: "number"
+      required: false
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Voor beoordeling of vergunning geweigerd moet worden"
+
+    - name: "heeft_beveiligingsplan"
+      description: "Of er een beveiligingsplan aanwezig is"
+      type: "boolean"
+      required: false
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Voor beoordeling of vergunning geweigerd moet worden"
+
+    - name: "heeft_noodplan"
+      description: "Of er een noodplan aanwezig is"
+      type: "boolean"
+      required: false
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Voor beoordeling of vergunning geweigerd moet worden"
+
+    - name: "financiele_zekerheid_bedrag"
+      description: "Bedrag van de gestelde financiële zekerheid"
+      type: "number"
+      required: false
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Voor beoordeling of vergunning geweigerd moet worden"
+
+    - name: "aantal_deskundigen"
+      description: "Aantal beschikbare deskundigen"
+      type: "number"
+      required: false
+      legal_basis:
+        law: "Kernenergiewet"
+        bwb_id: "BWBR0002402"
+        article: "15b"
+        paragraph: "1"
+        url: "https://wetten.overheid.nl/BWBR0002402/2024-07-01#Hoofdstuk3_Artikel15b"
+        juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
+        explanation: "Voor beoordeling of vergunning geweigerd moet worden"
+
   input:
     - name: "VERWACHTE_STRALINGSDOSIS"
       description: "Verwachte stralingsdosis per jaar in millisievert"
@@ -96,6 +187,13 @@ properties:
         service: "ANVS"
         law: "besluit_basisveiligheidsnormen_stralingsbescherming"
         field: "verwachte_dosis_bevolking"
+        parameters:
+          - name: "verwachte_dosis_jaar"
+            reference: "$verwachte_dosis_jaar"
+          - name: "verwachte_dosis_huid"
+            reference: "$verwachte_dosis_huid"
+          - name: "dosis_buiten_locatie"
+            reference: "$dosis_buiten_locatie"
       legal_basis:
         law: "Kernenergiewet"
         bwb_id: "BWBR0002402"
@@ -112,6 +210,15 @@ properties:
         service: "ANVS"
         law: "besluit_kerninstallaties"
         field: "financiele_zekerheid_gesteld"
+        parameters:
+          - name: "heeft_beveiligingsplan"
+            reference: "$heeft_beveiligingsplan"
+          - name: "heeft_noodplan"
+            reference: "$heeft_noodplan"
+          - name: "financiele_zekerheid_bedrag"
+            reference: "$financiele_zekerheid_bedrag"
+          - name: "aantal_deskundigen"
+            reference: "$aantal_deskundigen"
       legal_basis:
         law: "Kernenergiewet"
         bwb_id: "BWBR0002402"
@@ -178,28 +285,16 @@ properties:
     DOSIS_LIMIET_BEVOLKING: 1.0  # millisievert per jaar
 
 requirements:
-  - any:
-      - subject: "$activiteit_type"
-        operation: EQUALS
-        value: "$ACTIVITEIT_TRANSPORT"
-      - subject: "$activiteit_type"
-        operation: EQUALS
-        value: "$ACTIVITEIT_BEZIT"
-      - subject: "$activiteit_type"
-        operation: EQUALS
-        value: "$ACTIVITEIT_INVOER"
-      - subject: "$activiteit_type"
-        operation: EQUALS
-        value: "$ACTIVITEIT_UITVOER"
-      - subject: "$activiteit_type"
-        operation: EQUALS
-        value: "$ACTIVITEIT_INRICHTING_OPRICHTEN"
-      - subject: "$activiteit_type"
-        operation: EQUALS
-        value: "$ACTIVITEIT_INRICHTING_EXPLOITEREN"
-      - subject: "$activiteit_type"
-        operation: EQUALS
-        value: "$ACTIVITEIT_KERNVOORTSTUWING"
+  - subject: "$activiteit_type"
+    operation: IN
+    values:
+      - "transport"
+      - "bezit"
+      - "invoer"
+      - "uitvoer"
+      - "inrichting_oprichten"
+      - "inrichting_exploiteren"
+      - "kernvoortstuwing"
 
 actions:
   - output: "vergunning_vereist"
@@ -235,7 +330,7 @@ actions:
           juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
           explanation: "Artikel 15b lid 1 bepaalt dat vergunning geweigerd kan worden ter bescherming van mensen"
         then:
-          - "$WEIGERINGSGROND_VEILIGHEID"
+          - "bescherming_mensen_dieren_planten_goederen"
       - test:
           subject: "$HEEFT_FINANCIELE_ZEKERHEID"
           operation: EQUALS
@@ -249,7 +344,7 @@ actions:
           juriconnect: "jci1.3:c:BWBR0002402&artikel=15b&lid=1&z=2024-07-01&g=2024-07-01"
           explanation: "Artikel 15b lid 1 bepaalt dat vergunning geweigerd kan worden voor zekerheid van betaling schadevergoeding"
         then:
-          - "$WEIGERINGSGROND_SCHADEVERGOEDING"
+          - "zekerheid_betaling_schadevergoeding"
       - else: []
 
   - output: "vergunning_toegestaan"

--- a/laws/wet_brp/RvIG-2020-01-01.yaml
+++ b/laws/wet_brp/RvIG-2020-01-01.yaml
@@ -835,7 +835,7 @@ actions:
     operation: IF
     conditions:
       - test:
-          subject: "$HUISHOUDEN"
+          subject: "$KINDEREN_GEGEVENS"
           operation: NOT_NULL
           legal_basis:
             law: "Wet basisregistratie personen"
@@ -844,36 +844,9 @@ actions:
             url: "https://wetten.overheid.nl/BWBR0033715/2024-01-01#Hoofdstuk2_Paragraaf2.2_Artikel2.9"
             juriconnect: "jci1.3:c:BWBR0033715&artikel=2.9&z=2024-01-01&g=2024-01-01"
             explanation: "Artikel 2.9 Wet BRP bepaalt registratie van gegevens over kinderen"
-        then:
-          operation: FOREACH  # Gebruik FOREACH voor filtering
-          subject: "$HUISHOUDEN"
-          combine: "ADD"      # Combineer resultaten in een array
-          value:
-            operation: IF
-            conditions:
-              - test:
-                  operation: LESS_THAN
-                  values:
-                    - "$leeftijd"
-                    - 18
-                  legal_basis:
-                    law: "Wet basisregistratie personen"
-                    bwb_id: "BWBR0033715"
-                    article: "2.9"
-                    url: "https://wetten.overheid.nl/BWBR0033715/2024-01-01#Hoofdstuk2_Paragraaf2.2_Artikel2.9"
-                    juriconnect: "jci1.3:c:BWBR0033715&artikel=2.9&z=2024-01-01&g=2024-01-01"
-                    explanation: "Artikel 2.9 Wet BRP bepaalt meerderjarigheid op 18 jaar"
-                then: "$item"  # Voeg dit item toe als kind
-              - else: null     # Anders niets toevoegen
-          legal_basis:
-            law: "Wet basisregistratie personen"
-            bwb_id: "BWBR0033715"
-            article: "2.9"
-            url: "https://wetten.overheid.nl/BWBR0033715/2024-01-01#Hoofdstuk2_Paragraaf2.2_Artikel2.9"
-            juriconnect: "jci1.3:c:BWBR0033715&artikel=2.9&z=2024-01-01&g=2024-01-01"
-            explanation: "Artikel 2.9 Wet BRP maakt filtering van minderjarige kinderen mogelijk"
+        then: "$KINDEREN_GEGEVENS"
       - else:
-          value: null  # Leeg resultaat
+          value: null
     legal_basis:
       law: "Wet basisregistratie personen"
       bwb_id: "BWBR0033715"


### PR DESCRIPTION
## Summary
Fixed wet_brp `kinderen` output to use actual children data from relaties.kinderen ($KINDEREN_GEGEVENS) instead of household members ($HUISHOUDEN).

## Problem
The `kinderen` output was incorrectly using `$HUISHOUDEN` (people living at same address) and filtering by age < 18. This caused:
- Parent's birthdate (1988-10-16) showing as child's birthdate in UI
- Incorrect data passed to laws that depend on children information (huurtoeslag, kindgebonden_budget, etc.)

## Solution
- Changed subject from `$HUISHOUDEN` to `$KINDEREN_GEGEVENS`
- Removed FOREACH age filtering logic (no longer needed)
- Simplified to direct return of children data from relaties table

## Why This Is Correct
- **`$KINDEREN_GEGEVENS`**: Comes from `relaties.kinderen` table which contains parent-child relationships with actual children's data
- **`$HUISHOUDEN`**: Comes from `personen` table for people at same address - may include adults, roommates, etc.
- Laws like huurtoeslag need **actual children** (parent-child relationship), not just young household members

## Testing
✅ All behave tests pass:
- 16 features passed
- 70 scenarios passed
- 773 steps passed
- No regressions

## Related
Part of main PR in poc-machine-law that also fixes profiles.yaml to use correct field name.